### PR TITLE
Move `all_urls` permission to `optional_permissions`

### DIFF
--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -5,10 +5,12 @@
     "description": "A simple extension that allows a local MCP server to perform actions on the browser.",
     "permissions": [
         "tabs",
-        "*://*/*",
         "history",
         "find",
         "storage"
+    ],
+    "optional_permissions": [
+        "*://*/*"
     ],
     "background": {
       "scripts": ["dist/background.js"]


### PR DESCRIPTION
This PR moves the `*://*/*` permission from permissions to optional_permissions. This change enhances user privacy by making the "access all host" permission optional, requiring explicit user consent.