### PR TITLE
Add release workflow to generate DXT package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Build and Release MCP Server as DXT
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: 'npm'
+    
+    - name: Install root dependencies
+      run: npm install
+    
+    - name: Install MCP server dependencies
+      run: npm install --prefix mcp-server
+    
+    - name: Build MCP server package
+      run: cd mcp-server && npm run pack-dxt
+    
+    - name: Rename package file with version
+      run: |
+        cd mcp-server
+        mv mcp-server.dxt mcp-server-${{ github.event.release.tag_name }}.dxt
+    
+    - name: Upload package to release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./mcp-server/mcp-server-${{ github.event.release.tag_name }}.dxt
+        asset_name: mcp-server-${{ github.event.release.tag_name }}.dxt
+        asset_content_type: application/octet-stream
+

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,7 @@ dist
 
 .nx
 
+# DXT
+*.dxt
+
 .DS_Store

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -1,0 +1,82 @@
+{
+    "dxt_version": "0.1",
+    "name": "browser-control-firefox",
+    "version": "1.3.1",
+    "display_name": "Firefox Control",
+    "description": "Control Mozilla Firefox: tabs, history and web content (privacy aware)",
+    "author": {
+        "name": "eyalzh",
+        "url": "https://github.com/eyalzh"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/eyalzh/browser-control-mcp"
+    },
+    "support": "https://github.com/eyalzh/browser-control-mcp/issues",
+    "documentation": "https://github.com/eyalzh/browser-control-mcp",
+    "license": "MIT",
+    "keywords": [
+        "browser",
+        "firefox"
+    ],
+    "server": {
+        "type": "node",
+        "entry_point": "dist/server.js",
+        "mcp_config": {
+            "command": "node",
+            "args": [
+                "${__dirname}/dist/server.js"
+            ],
+            "env": {
+                "EXTENSION_SECRET": "${user_config.extension_secret}",
+                "EXTENSION_PORT": "${user_config.port}"
+            }
+        }
+    },
+    "user_config": {
+        "extension_secret": {
+            "type": "string",
+            "title": "Firefox Extension Secret",
+            "description": "The secret key provided by the Firefox extension",
+            "sensitive": true,
+            "required": true
+        },
+        "port": {
+            "type": "string",
+            "title": "Extension Port",
+            "description": "The port that the MCP server will use to communicate with the Firefox extension (default is 8089)",
+            "default": "8089",
+            "required": false
+        }
+    },
+    "tools": [
+        {
+            "name": "open-browser-tab",
+            "description": "Open a new tab in the browser"
+        },
+        {
+            "name": "close-browser-tabs",
+            "description": "Close tabs in the browser"
+        },
+        {
+            "name": "get-list-of-open-tabs",
+            "description": "Get the list of open tabs in the browser"
+        },
+        {
+            "name": "get-recent-browser-history",
+            "description": "Get the list of recent browser history"
+        },
+        {
+            "name": "get-tab-web-content",
+            "description": "Get the full text content of the webpage and the list of links in the webpage (requires user consent)"
+        },
+        {
+            "name": "reorder-browser-tabs",
+            "description": "Change the order of open browser tabs"
+        },
+        {
+            "name": "find-highlight-in-browser-tab",
+            "description": "Find and highlight text in a browser tab"
+        }
+    ]
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "pack-dxt": "npx @anthropic-ai/dxt pack"
   },
   "license": "MIT",
   "description": "Browser Control MCP Server",


### PR DESCRIPTION
This utilizes Anthropic's new Desktop Extension (.dxt) format, to simplify the installation process of the MCP server in Claude Desktop. 

See: https://github.com/anthropics/dxt/tree/main