### PR TITLE
Add group tabs tool

### DIFF
--- a/common/extension-messages.ts
+++ b/common/extension-messages.ts
@@ -55,6 +55,11 @@ export interface TabsClosedExtensionMessage extends ExtensionMessageBase {
   resource: "tabs-closed";
 }
 
+export interface TabGroupCreatedExtensionMessage extends ExtensionMessageBase {
+  resource: "new-tab-group";
+  groupId: number;
+}
+
 export type ExtensionMessage =
   | TabContentExtensionMessage
   | TabsExtensionMessage
@@ -62,7 +67,8 @@ export type ExtensionMessage =
   | BrowserHistoryExtensionMessage
   | ReorderedTabsExtensionMessage
   | FindHighlightExtensionMessage
-  | TabsClosedExtensionMessage;
+  | TabsClosedExtensionMessage
+  | TabGroupCreatedExtensionMessage;
 
 export interface ExtensionError {
   correlationId: string;

--- a/common/server-messages.ts
+++ b/common/server-messages.ts
@@ -38,6 +38,14 @@ export interface FindHighlightServerMessage extends ServerMessageBase {
   queryPhrase: string;
 }
 
+export interface GroupTabsServerMessage extends ServerMessageBase {
+  cmd: "group-tabs";
+  tabIds: number[];
+  isCollapsed: boolean;
+  groupColor: string;
+  groupTitle: string;
+}
+
 export type ServerMessage =
   | OpenTabServerMessage
   | CloseTabsServerMessage
@@ -45,6 +53,7 @@ export type ServerMessage =
   | GetBrowserRecentHistoryServerMessage
   | GetTabContentServerMessage
   | ReorderTabsServerMessage
-  | FindHighlightServerMessage;
+  | FindHighlightServerMessage
+  | GroupTabsServerMessage;
 
 export type ServerMessageRequest = ServerMessage & { correlationId: string };

--- a/firefox-extension/extension-config.ts
+++ b/firefox-extension/extension-config.ts
@@ -41,8 +41,8 @@ export const AVAILABLE_TOOLS: ToolInfo[] = [
   },
   {
     id: "reorder-browser-tabs",
-    name: "Reorder Browser Tabs",
-    description: "Allows the MCP server to change the order of your browser tabs"
+    name: "Reorder/Group Browser Tabs",
+    description: "Allows the MCP server to reorder/group your browser tabs"
   },
   {
     id: "find-highlight-in-browser-tab",
@@ -59,7 +59,8 @@ export const COMMAND_TO_TOOL_ID: Record<ServerMessageRequest["cmd"], string> = {
   "get-browser-recent-history": "get-recent-browser-history",
   "get-tab-content": "get-tab-web-content",
   "reorder-tabs": "reorder-browser-tabs",
-  "find-highlight": "find-highlight-in-browser-tab"
+  "find-highlight": "find-highlight-in-browser-tab",
+  "group-tabs": "reorder-browser-tabs",
 };
 
 // Storage schema for tool settings

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -1,10 +1,11 @@
 {
     "manifest_version": 2,
     "name": "Browser Control MCP",
-    "version": "1.3.1",
+    "version": "1.4",
     "description": "An extension that allows a local MCP server to perform actions on the browser.",
     "permissions": [
         "tabs",
+        "tabGroups",
         "history",
         "find",
         "storage"

--- a/firefox-extension/package-lock.json
+++ b/firefox-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firefox-extension",
-  "version": "1.3.1",
+  "version": "1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firefox-extension",
-      "version": "1.3.1",
+      "version": "1.4",
       "license": "MIT",
       "devDependencies": {
         "@browser-control-mcp/common": "../common",

--- a/firefox-extension/package.json
+++ b/firefox-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-extension",
-  "version": "1.3.1",
+  "version": "1.4",
   "main": "dist/background.js",
   "scripts": {
     "build": "esbuild background.ts --bundle --outfile=dist/background.js && esbuild options.ts --bundle --outfile=dist/options.js",

--- a/firefox-extension/types/browserTabGroups.d.ts
+++ b/firefox-extension/types/browserTabGroups.d.ts
@@ -1,0 +1,38 @@
+// See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabGroups/update
+// This is a partial type representation of the browser.tabGroups API.
+
+declare namespace browser.tabGroups {
+  type Color =
+    | "blue"
+    | "cyan"
+    | "grey"
+    | "green"
+    | "orange"
+    | "pink"
+    | "purple"
+    | "red"
+    | "yellow";
+
+  interface TabGroup {
+    id: number;
+  }
+
+  interface GroupUpdateProperties {
+    collapsed?: boolean;
+    color?: Color;
+    title?: string;
+  }
+
+  function update(
+    groupId: number,
+    updateProperties: GroupUpdateProperties
+  ): Promise<TabGroup>;
+}
+
+declare namespace browser.tabs {
+  interface GroupOptions {
+    tabIds: number[];
+  }
+
+  function group(options: GroupOptions): Promise<number>;
+}

--- a/mcp-server/browser-api.ts
+++ b/mcp-server/browser-api.ts
@@ -151,6 +151,23 @@ export class BrowserAPI {
     return message.noOfResults;
   }
 
+  async groupTabs(
+    tabIds: number[],
+    isCollapsed: boolean,
+    groupColor: string,
+    groupTitle: string
+  ): Promise<number> {
+    const correlationId = this.sendMessageToExtension({
+      cmd: "group-tabs",
+      tabIds,
+      isCollapsed,
+      groupColor,
+      groupTitle,
+    });
+    const message = await this.waitForResponse(correlationId, "new-tab-group");
+    return message.groupId;
+  }
+
   private createSignature(payload: string): string {
     if (!this.sharedSecret) {
       throw new Error("Shared secret not initialized");

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -1,7 +1,7 @@
 {
     "dxt_version": "0.1",
     "name": "browser-control-firefox",
-    "version": "1.3.1",
+    "version": "1.4",
     "display_name": "Firefox Control",
     "description": "Control Mozilla Firefox: tabs, history and web content (privacy aware)",
     "author": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-server",
-  "version": "1.3.1",
+  "version": "1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-server",
-      "version": "1.3.1",
+      "version": "1.4",
       "license": "MIT",
       "dependencies": {
         "@browser-control-mcp/common": "../common",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server",
-  "version": "1.3.1",
+  "version": "1.4",
   "main": "dist/server.js",
   "engines": {
     "node": ">=22.0.0"

--- a/mcp-server/server.ts
+++ b/mcp-server/server.ts
@@ -12,7 +12,7 @@ dayjs.extend(relativeTime);
 
 const mcpServer = new McpServer({
   name: "BrowserControl",
-  version: "1.3.1",
+  version: "1.4",
 });
 
 mcpServer.tool(
@@ -171,6 +171,28 @@ mcpServer.tool(
         {
           type: "text",
           text: `Number of results found and highlighted in the tab: ${noOfResults}`,
+        },
+      ],
+    };
+  }
+);
+
+mcpServer.tool(
+  "group-browser-tabs",
+  "Organize opened browser tabs in a new tab group",
+  {
+    tabIds: z.array(z.number()),
+    isCollapsed: z.boolean().default(false),
+    groupColor: z.enum(["grey", "blue", "red", "yellow", "green", "pink", "purple", "cyan", "orange"]).default("grey"),
+    groupTitle: z.string().default("New Group"),
+  },
+  async ({ tabIds, isCollapsed, groupColor, groupTitle }) => {
+    const groupId = await browserApi.groupTabs(tabIds, isCollapsed, groupColor, groupTitle);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Created tab group "${groupTitle}" with ${tabIds.length} tabs (group ID: ${groupId})`,
         },
       ],
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browser-control-mcp",
-  "version": "1.3.1",
+  "version": "1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browser-control-mcp",
-      "version": "1.3.1",
+      "version": "1.4",
       "devDependencies": {
         "nx": "20.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-control-mcp",
-  "version": "1.3.1",
+  "version": "1.4",
   "private": true,
   "scripts": {
     "build": "nx run-many --target=build --all --parallel"


### PR DESCRIPTION
Add a new tool: `group-browser-tabs`

The tab grouping feature is now part of newer Firefox versions, allowing extensions to organize tabs in named and colored groups (Firefox >= 138).

# Example use-cases:
* **"Group all the work-related tabs in my browser in a single group called 'work'"**
* **"Group all tabs which have similar domains into groups whose name is the domain"**