### PR TITLE
Fix startup WebSocket readiness

### DIFF
--- a/firefox-extension/__tests__/client.test.ts
+++ b/firefox-extension/__tests__/client.test.ts
@@ -1,0 +1,103 @@
+import { WebsocketClient } from "../client";
+
+class MockWebSocket extends EventTarget {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  sentMessages: string[] = [];
+
+  constructor(readonly url: string) {
+    super();
+    MockWebSocket.instances.push(this);
+  }
+
+  send(message: string) {
+    this.sentMessages.push(message);
+  }
+
+  close() {
+    if (this.readyState === MockWebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = MockWebSocket.CLOSED;
+    this.dispatchEvent(new Event("close"));
+  }
+}
+
+describe("WebsocketClient", () => {
+  const originalWebSocket = global.WebSocket;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    MockWebSocket.instances = [];
+    Object.defineProperty(global, "WebSocket", {
+      value: MockWebSocket,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    Object.defineProperty(global, "WebSocket", {
+      value: originalWebSocket,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("reconnects after the websocket closes", () => {
+    const client = new WebsocketClient(8089, "test-secret");
+
+    client.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    MockWebSocket.instances[0].close();
+    jest.advanceTimersByTime(1999);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    jest.advanceTimersByTime(1);
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(MockWebSocket.instances[1].url).toBe("ws://localhost:8089");
+  });
+
+  it("retries when a websocket stays stuck connecting", () => {
+    const client = new WebsocketClient(8089, "test-secret");
+
+    client.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    jest.advanceTimersByTime(1999);
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].readyState).toBe(MockWebSocket.CONNECTING);
+
+    jest.advanceTimersByTime(1);
+    expect(MockWebSocket.instances[0].readyState).toBe(MockWebSocket.CLOSED);
+
+    jest.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("does not create duplicate sockets while already connecting", () => {
+    const client = new WebsocketClient(8089, "test-secret");
+
+    client.connect();
+    client.connect();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("does not reconnect after an explicit disconnect", () => {
+    const client = new WebsocketClient(8089, "test-secret");
+
+    client.connect();
+    client.disconnect();
+    jest.advanceTimersByTime(2000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/firefox-extension/client.ts
+++ b/firefox-extension/client.ts
@@ -6,13 +6,14 @@ import type {
 import { getMessageSignature } from "./auth";
 
 const RECONNECT_INTERVAL = 2000; // 2 seconds
+const CONNECT_TIMEOUT = 2000; // 2 seconds
 
 export class WebsocketClient {
   private socket: WebSocket | null = null;
   private readonly port: number;
   private readonly secret: string;
   private reconnectTimer: number | null = null;
-  private connectionAttempts: number = 0;
+  private manuallyDisconnected = false;
   private messageCallback: ((data: ServerMessageRequest) => void) | null = null;
 
   constructor(port: number, secret: string) {
@@ -21,25 +22,55 @@ export class WebsocketClient {
   }
 
   public connect(): void {
+    this.manuallyDisconnected = false;
+    if (
+      this.socket &&
+      (this.socket.readyState === WebSocket.OPEN ||
+        this.socket.readyState === WebSocket.CONNECTING)
+    ) {
+      return;
+    }
+
     console.log("Connecting to WebSocket server at port", this.port);
+    this.clearReconnectTimer();
 
-    this.socket = new WebSocket(`ws://localhost:${this.port}`);
+    const socket = new WebSocket(`ws://localhost:${this.port}`);
+    this.socket = socket;
+    const connectTimeout = window.setTimeout(() => {
+      if (
+        this.socket === socket &&
+        socket.readyState === WebSocket.CONNECTING
+      ) {
+        console.log("WebSocket connection attempt timed out at port", this.port);
+        socket.close();
+      }
+    }, CONNECT_TIMEOUT);
 
-    this.socket.addEventListener("open", () => {
+    socket.addEventListener("open", () => {
+      window.clearTimeout(connectTimeout);
       console.log("Connected to WebSocket server at port", this.port);
-      this.connectionAttempts = 0;
     });
 
-    this.socket.addEventListener("close", () => {
+    socket.addEventListener("close", () => {
+      window.clearTimeout(connectTimeout);
       console.log("WebSocket connection closed event at port", this.port);
-      this.connectionAttempts = 0;
+      if (this.socket === socket) {
+        this.socket = null;
+      }
+      this.scheduleReconnect();
     });
 
-    this.socket.addEventListener("error", (event) => {
+    socket.addEventListener("error", (event) => {
       console.error("WebSocket error:", event);
+      if (
+        socket.readyState !== WebSocket.CLOSING &&
+        socket.readyState !== WebSocket.CLOSED
+      ) {
+        socket.close();
+      }
     });
 
-    this.socket.addEventListener("message", async (event) => {
+    socket.addEventListener("message", async (event) => {
       if (this.messageCallback === null) {
         return;
       }
@@ -62,11 +93,6 @@ export class WebsocketClient {
         console.error("Failed to parse message:", error);
       }
     });
-
-    // Start reconnection timer if not already running
-    if (this.reconnectTimer === null) {
-      this.startReconnectTimer();
-    }
   }
 
   public addMessageListener(
@@ -75,26 +101,29 @@ export class WebsocketClient {
     this.messageCallback = callback;
   }
 
-  private startReconnectTimer(): void {
-    this.reconnectTimer = window.setInterval(() => {
-      if (this.socket && this.socket.readyState === WebSocket.CONNECTING) {
-        this.connectionAttempts++;
+  private scheduleReconnect(): void {
+    if (this.manuallyDisconnected || this.reconnectTimer !== null) {
+      return;
+    }
 
-        if (this.connectionAttempts > 2) {
-          // Avoid long retry backoff periods by resetting the connection
-          this.socket.close();
-        }
-      }
-
-      if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
-        this.connect();
-      }
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
     }, RECONNECT_INTERVAL);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer === null) {
+      return;
+    }
+    window.clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
   }
 
   public async sendResourceToServer(resource: ExtensionMessage): Promise<void> {
     if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
       console.error("Socket is not open");
+      this.scheduleReconnect();
       return;
     }
     const signedMessage = {
@@ -113,6 +142,7 @@ export class WebsocketClient {
   ): Promise<void> {
     if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
       console.error("Socket is not open", this.socket);
+      this.scheduleReconnect();
       return;
     }
     const extensionError: ExtensionError = {
@@ -123,10 +153,8 @@ export class WebsocketClient {
   }
 
   public disconnect(): void {
-    if (this.reconnectTimer !== null) {
-      window.clearInterval(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
+    this.manuallyDisconnected = true;
+    this.clearReconnectTimer();
 
     if (this.socket) {
       this.socket.close();

--- a/mcp-server/browser-api.ts
+++ b/mcp-server/browser-api.ts
@@ -13,20 +13,29 @@ import * as crypto from "crypto";
 
 const WS_DEFAULT_PORT = 8089;
 const EXTENSION_RESPONSE_TIMEOUT_MS = 1000;
+const EXTENSION_CONNECTION_TIMEOUT_MS = 10_000;
 
 interface ExtensionRequestResolver<T extends ExtensionMessage["resource"]> {
   resource: T;
   resolve: (value: Extract<ExtensionMessage, { resource: T }>) => void;
-  reject: (reason?: string) => void;
+  reject: (reason?: unknown) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+interface ExtensionConnectionWaiter {
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+  timeout: ReturnType<typeof setTimeout>;
 }
 
 export class BrowserAPI {
   private ws: WebSocket | null = null;
   private wsServer: WebSocket.Server | null = null;
   private sharedSecret: string | null = null;
+  private connectionWaiters: ExtensionConnectionWaiter[] = [];
 
-  // Map to persist the request to the extension. It maps the request correlationId
-  // to a resolver, fulfulling a promise created when sending a message to the extension.
+  // Tracks extension requests by correlationId so responses can resolve the
+  // matching command promise.
   private extensionRequestMap: Map<
     string,
     ExtensionRequestResolver<ExtensionMessage["resource"]>
@@ -60,8 +69,9 @@ export class BrowserAPI {
       this.ws = connection;
 
       console.error("WebSocket connection established on port", port);
+      this.resolveConnectionWaiters();
 
-      this.ws.on("message", (message) => {
+      connection.on("message", (message) => {
         const decoded = JSON.parse(message.toString());
         if (isErrorMessage(decoded)) {
           this.handleExtensionError(decoded);
@@ -74,6 +84,16 @@ export class BrowserAPI {
         }
         this.handleDecodedExtensionMessage(decoded.payload);
       });
+
+      connection.on("close", () => {
+        const wasCurrentConnection = this.ws === connection;
+        if (wasCurrentConnection) {
+          this.ws = null;
+          this.rejectPendingExtensionRequests(
+            "Firefox extension disconnected before responding"
+          );
+        }
+      });
     });
     this.wsServer.on("error", (error) => {
       console.error("WebSocket server error:", error);
@@ -81,6 +101,9 @@ export class BrowserAPI {
   }
 
   close() {
+    this.rejectConnectionWaiters(
+      "MCP server closed before the extension connected"
+    );
     this.wsServer?.close();
   }
 
@@ -89,7 +112,7 @@ export class BrowserAPI {
   }
 
   async openTab(url: string): Promise<number | undefined> {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "open-tab",
       url,
     });
@@ -98,7 +121,7 @@ export class BrowserAPI {
   }
 
   async closeTabs(tabIds: number[]) {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "close-tabs",
       tabIds,
     });
@@ -106,7 +129,7 @@ export class BrowserAPI {
   }
 
   async getTabList(): Promise<BrowserTab[]> {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "get-tab-list",
     });
     const message = await this.waitForResponse(correlationId, "tabs");
@@ -116,7 +139,7 @@ export class BrowserAPI {
   async getBrowserRecentHistory(
     searchQuery?: string
   ): Promise<BrowserHistoryItem[]> {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "get-browser-recent-history",
       searchQuery,
     });
@@ -128,7 +151,7 @@ export class BrowserAPI {
     tabId: number,
     offset: number
   ): Promise<TabContentExtensionMessage> {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "get-tab-content",
       tabId,
       offset,
@@ -137,7 +160,7 @@ export class BrowserAPI {
   }
 
   async reorderTabs(tabOrder: number[]): Promise<number[]> {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "reorder-tabs",
       tabOrder,
     });
@@ -146,7 +169,7 @@ export class BrowserAPI {
   }
 
   async findHighlight(tabId: number, queryPhrase: string): Promise<number> {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "find-highlight",
       tabId,
       queryPhrase,
@@ -164,7 +187,7 @@ export class BrowserAPI {
     groupColor: string,
     groupTitle: string
   ): Promise<number> {
-    const correlationId = this.sendMessageToExtension({
+    const correlationId = await this.sendMessageToExtension({
       cmd: "group-tabs",
       tabIds,
       isCollapsed,
@@ -184,7 +207,8 @@ export class BrowserAPI {
     return hmac.digest("hex");
   }
 
-  private sendMessageToExtension(message: ServerMessage): string {
+  private async sendMessageToExtension(message: ServerMessage): Promise<string> {
+    await this.waitForExtensionConnection();
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error("WebSocket is not open");
     }
@@ -206,20 +230,30 @@ export class BrowserAPI {
 
   private handleDecodedExtensionMessage(decoded: ExtensionMessage) {
     const { correlationId } = decoded;
-    const { resolve, resource } = this.extensionRequestMap.get(correlationId)!;
-    if (resource !== decoded.resource) {
-      console.error("Resource mismatch:", resource, decoded.resource);
+    const resolver = this.extensionRequestMap.get(correlationId);
+    if (!resolver) {
+      console.error("No pending request for correlationId:", correlationId);
+      return;
+    }
+    if (resolver.resource !== decoded.resource) {
+      console.error("Resource mismatch:", resolver.resource, decoded.resource);
       return;
     }
     this.extensionRequestMap.delete(correlationId);
-    resolve(decoded);
+    clearTimeout(resolver.timeout);
+    resolver.resolve(decoded);
   }
 
   private handleExtensionError(decoded: ExtensionError) {
     const { correlationId, errorMessage } = decoded;
-    const { reject } = this.extensionRequestMap.get(correlationId)!;
+    const resolver = this.extensionRequestMap.get(correlationId);
+    if (!resolver) {
+      console.error("No pending request for correlationId:", correlationId);
+      return;
+    }
     this.extensionRequestMap.delete(correlationId);
-    reject(errorMessage);
+    clearTimeout(resolver.timeout);
+    resolver.reject(errorMessage);
   }
 
   private async waitForResponse<T extends ExtensionMessage["resource"]>(
@@ -228,17 +262,68 @@ export class BrowserAPI {
   ): Promise<Extract<ExtensionMessage, { resource: T }>> {
     return new Promise<Extract<ExtensionMessage, { resource: T }>>(
       (resolve, reject) => {
+        const timeout = setTimeout(() => {
+          if (this.extensionRequestMap.delete(correlationId)) {
+            reject("Timed out waiting for response");
+          }
+        }, EXTENSION_RESPONSE_TIMEOUT_MS);
+
         this.extensionRequestMap.set(correlationId, {
           resolve: resolve as (value: ExtensionMessage) => void,
           resource,
           reject,
+          timeout,
         });
-        setTimeout(() => {
-          this.extensionRequestMap.delete(correlationId);
-          reject("Timed out waiting for response");
-        }, EXTENSION_RESPONSE_TIMEOUT_MS);
       }
     );
+  }
+
+  private async waitForExtensionConnection(): Promise<void> {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      return;
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.connectionWaiters = this.connectionWaiters.filter(
+          (waiter) => waiter.timeout !== timeout
+        );
+        reject(
+          "Timed out waiting for the Firefox extension websocket connection. Ensure the add-on is enabled and its port/secret match the MCP server."
+        );
+      }, EXTENSION_CONNECTION_TIMEOUT_MS);
+
+      this.connectionWaiters.push({
+        resolve,
+        reject,
+        timeout,
+      });
+    });
+  }
+
+  private resolveConnectionWaiters() {
+    const waiters = this.connectionWaiters.splice(0);
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve();
+    }
+  }
+
+  private rejectConnectionWaiters(reason: string) {
+    const waiters = this.connectionWaiters.splice(0);
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(reason);
+    }
+  }
+
+  private rejectPendingExtensionRequests(reason: string) {
+    const pendingRequests = Array.from(this.extensionRequestMap.values());
+    this.extensionRequestMap.clear();
+    for (const request of pendingRequests) {
+      clearTimeout(request.timeout);
+      request.reject(reason);
+    }
   }
 }
 

--- a/mcp-server/browser-api.ts
+++ b/mcp-server/browser-api.ts
@@ -12,8 +12,25 @@ import { isPortInUse } from "./util";
 import * as crypto from "crypto";
 
 const WS_DEFAULT_PORT = 8089;
-const EXTENSION_RESPONSE_TIMEOUT_MS = 1000;
-const EXTENSION_CONNECTION_TIMEOUT_MS = 10_000;
+
+function readPositiveTimeout(name: string, fallback: number): number {
+  const configured = process.env[name];
+  if (!configured) {
+    return fallback;
+  }
+
+  const timeout = Number(configured);
+  return Number.isFinite(timeout) && timeout > 0 ? timeout : fallback;
+}
+
+const EXTENSION_RESPONSE_TIMEOUT_MS = readPositiveTimeout(
+  "BROWSER_CONTROL_MCP_RESPONSE_TIMEOUT_MS",
+  5_000
+);
+const EXTENSION_CONNECTION_TIMEOUT_MS = readPositiveTimeout(
+  "BROWSER_CONTROL_MCP_CONNECTION_TIMEOUT_MS",
+  30_000
+);
 
 interface ExtensionRequestResolver<T extends ExtensionMessage["resource"]> {
   resource: T;


### PR DESCRIPTION
## Why

Extension-bound tool calls can arrive while Firefox is still reconnecting to a newly started MCP server. A real desktop startup took longer than the previous 10-second readiness window, so a short-lived client exited even though Firefox connected successfully once the server remained available.

## Outcome

- Wait up to a configurable 30 seconds for the Firefox extension websocket before sending commands.
- Wait up to a configurable 5 seconds for extension responses.
- Reject pending requests when the active socket disconnects.
- Retry stale `CONNECTING` sockets without creating duplicate connections.
- Cover reconnect and readiness behavior with focused tests.

The timeout overrides are `BROWSER_CONTROL_MCP_CONNECTION_TIMEOUT_MS` and `BROWSER_CONTROL_MCP_RESPONSE_TIMEOUT_MS`; invalid values retain the defaults.

## Validation

- `npm run build`
- `npm test -- --runInBand` in `firefox-extension` (13 tests passed)
- Confirmed the installed Firefox extension established its websocket after the wake path and remained connected on port 8089
