### PR TITLE
Add container-aware Firefox tab tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [![Firefox Add-on](./.github/addon_badge.svg)](https://addons.mozilla.org/en-US/firefox/addon/browser-control-mcp/)
 
-An MCP server paired with a Firefox browser extension that provides AI assistants with access to tab management, browsing history, and webpage text content.
+An MCP server paired with a Firefox browser extension that provides AI assistants with access to tab management, Firefox containers, browsing history, and webpage text content.
 
 ## Features
 
 The MCP server supports the following tools:
 - Open or close tabs
-- Get the list of opened tabs
+- Get the list of opened tabs, including container metadata
+- Activate an existing tab and focus its window
+- List available Firefox containers
 - Create tab groups with name and color
 - Reorder opened tabs
 - Read and search the browser's history
@@ -19,6 +21,7 @@ The MCP server supports the following tools:
 
 ### Tab management
 - *"Close all non-work-related tabs in my browser."*
+- *"List my Firefox containers and open this URL in the Work container."*
 - *"Group all development related tabs in my browser into a new group called 'Development'."*
 - *"Rearrange tabs in my browser in an order that makes sense."*
 - *"Close all tabs in my browser that haven't been accessed within the past 24 hours"*
@@ -42,6 +45,7 @@ The MCP server and Firefox extension combo is designed to be more secure than we
 * No remote data collection or tracking.
 * It provides an extension-side audit log for tool calls and tool enable/disable configuration.
 * The extension includes no runtime third-party dependencies.
+* Firefox container support requires the extension permissions `contextualIdentities` and `cookies`.
 
 **Important note**: Browser Control MCP is still experimental. Use at your own risk. You should practice caution as with any other MCP server and authorize/monitor tool calls carefully.
 
@@ -129,4 +133,3 @@ and use the following mcpServers configuration:
     }
 }
 ```
-

--- a/common/extension-messages.ts
+++ b/common/extension-messages.ts
@@ -3,6 +3,14 @@ export interface ExtensionMessageBase {
   correlationId: string;
 }
 
+export interface BrowserContainer {
+  cookieStoreId: string;
+  name: string;
+  color: string;
+  colorCode?: string;
+  icon: string;
+}
+
 export interface TabContentExtensionMessage extends ExtensionMessageBase {
   resource: "tab-content";
   tabId: number;
@@ -14,9 +22,15 @@ export interface TabContentExtensionMessage extends ExtensionMessageBase {
 
 export interface BrowserTab {
   id?: number;
+  windowId?: number;
+  index?: number;
   url?: string;
   title?: string;
   lastAccessed?: number;
+  active?: boolean;
+  pinned?: boolean;
+  cookieStoreId?: string;
+  container?: BrowserContainer | null;
 }
 
 export interface TabsExtensionMessage extends ExtensionMessageBase {
@@ -27,6 +41,19 @@ export interface TabsExtensionMessage extends ExtensionMessageBase {
 export interface OpenedTabIdExtensionMessage extends ExtensionMessageBase {
   resource: "opened-tab-id";
   tabId: number | undefined;
+  tab?: BrowserTab;
+}
+
+export interface ActivatedTabExtensionMessage extends ExtensionMessageBase {
+  resource: "activated-tab";
+  tabId: number | undefined;
+  windowId: number | undefined;
+  tab?: BrowserTab;
+}
+
+export interface ContainersExtensionMessage extends ExtensionMessageBase {
+  resource: "containers";
+  containers: BrowserContainer[];
 }
 
 export interface BrowserHistoryItem {
@@ -64,6 +91,8 @@ export type ExtensionMessage =
   | TabContentExtensionMessage
   | TabsExtensionMessage
   | OpenedTabIdExtensionMessage
+  | ActivatedTabExtensionMessage
+  | ContainersExtensionMessage
   | BrowserHistoryExtensionMessage
   | ReorderedTabsExtensionMessage
   | FindHighlightExtensionMessage

--- a/common/server-messages.ts
+++ b/common/server-messages.ts
@@ -5,6 +5,7 @@ export interface ServerMessageBase {
 export interface OpenTabServerMessage extends ServerMessageBase {
   cmd: "open-tab";
   url: string;
+  container?: string;
 }
 
 export interface CloseTabsServerMessage extends ServerMessageBase {
@@ -14,6 +15,14 @@ export interface CloseTabsServerMessage extends ServerMessageBase {
 
 export interface GetTabListServerMessage extends ServerMessageBase {
   cmd: "get-tab-list";
+  container?: string;
+  windowId?: number;
+  activeOnly?: boolean;
+}
+
+export interface ActivateTabServerMessage extends ServerMessageBase {
+  cmd: "activate-tab";
+  tabId: number;
 }
 
 export interface GetBrowserRecentHistoryServerMessage extends ServerMessageBase {
@@ -46,14 +55,20 @@ export interface GroupTabsServerMessage extends ServerMessageBase {
   groupTitle: string;
 }
 
+export interface GetContainerListServerMessage extends ServerMessageBase {
+  cmd: "get-container-list";
+}
+
 export type ServerMessage =
   | OpenTabServerMessage
   | CloseTabsServerMessage
   | GetTabListServerMessage
+  | ActivateTabServerMessage
   | GetBrowserRecentHistoryServerMessage
   | GetTabContentServerMessage
   | ReorderTabsServerMessage
   | FindHighlightServerMessage
-  | GroupTabsServerMessage;
+  | GroupTabsServerMessage
+  | GetContainerListServerMessage;
 
 export type ServerMessageRequest = ServerMessage & { correlationId: string };

--- a/firefox-extension/__tests__/message-handler.test.ts
+++ b/firefox-extension/__tests__/message-handler.test.ts
@@ -3,7 +3,6 @@ import { WebsocketClient } from "../client";
 import type { ServerMessageRequest } from "@browser-control-mcp/common";
 import { ExtensionConfig } from "../extension-config";
 
-// Mock the WebsocketClient
 jest.mock("../client", () => {
   return {
     WebsocketClient: jest.fn().mockImplementation(() => {
@@ -20,23 +19,22 @@ describe("MessageHandler", () => {
   let mockClient: jest.Mocked<WebsocketClient>;
 
   beforeEach(() => {
-    // Clear all mocks before each test
     jest.clearAllMocks();
 
-    // Create a new instance of WebsocketClient and MessageHandler
     mockClient = new WebsocketClient(
       8080,
       "test-secret"
     ) as jest.Mocked<WebsocketClient>;
     messageHandler = new MessageHandler(mockClient);
 
-    // Mock browser.storage.local.get to return default config
     const defaultConfig: ExtensionConfig = {
       secret: "test-secret",
       toolSettings: {
         "open-browser-tab": true,
         "close-browser-tabs": true,
         "get-list-of-open-tabs": true,
+        "activate-browser-tab": true,
+        "list-browser-containers": true,
         "get-recent-browser-history": true,
         "get-tab-web-content": true,
         "reorder-browser-tabs": true,
@@ -50,504 +48,602 @@ describe("MessageHandler", () => {
     (browser.storage.local.get as jest.Mock).mockResolvedValue({
       config: defaultConfig,
     });
+    (browser.contextualIdentities.query as jest.Mock).mockResolvedValue([]);
   });
 
-  describe("handleDecodedMessage", () => {
-    it("should throw an error if command is not allowed", async () => {
-      // Arrange
-      const configWithDisabledOpenTab: ExtensionConfig = {
+  it("opens a default tab when no container is requested", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "open-tab",
+      url: "https://example.com",
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.tabs.create as jest.Mock).mockResolvedValue({
+      id: 123,
+      windowId: 7,
+      index: 0,
+      url: "https://example.com",
+      title: "Example",
+      active: false,
+      pinned: false,
+      cookieStoreId: "firefox-default",
+    });
+
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: "https://example.com",
+    });
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: "opened-tab-id",
+        correlationId: "test-correlation-id",
+        tabId: 123,
+        tab: expect.objectContaining({
+          id: 123,
+          cookieStoreId: "firefox-default",
+          container: null,
+        }),
+      })
+    );
+  });
+
+  it("opens a tab in a requested container by cookieStoreId", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "open-tab",
+      url: "https://example.com",
+      container: "firefox-container-2",
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.contextualIdentities.query as jest.Mock).mockResolvedValue([
+      {
+        cookieStoreId: "firefox-container-2",
+        name: "Work",
+        color: "blue",
+        colorCode: "#37adff",
+        icon: "briefcase",
+      },
+    ]);
+    (browser.tabs.create as jest.Mock).mockResolvedValue({
+      id: 123,
+      windowId: 7,
+      index: 0,
+      url: "https://example.com",
+      title: "Example",
+      active: false,
+      pinned: false,
+      cookieStoreId: "firefox-container-2",
+    });
+
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: "https://example.com",
+      cookieStoreId: "firefox-container-2",
+    });
+  });
+
+  it("opens a tab in a requested container by exact name", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "open-tab",
+      url: "https://example.com",
+      container: "Work",
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.contextualIdentities.query as jest.Mock).mockResolvedValue([
+      {
+        cookieStoreId: "firefox-container-2",
+        name: "Work",
+        color: "blue",
+        colorCode: "#37adff",
+        icon: "briefcase",
+      },
+    ]);
+    (browser.tabs.create as jest.Mock).mockResolvedValue({
+      id: 123,
+      windowId: 7,
+      index: 0,
+      url: "https://example.com",
+      title: "Example",
+      active: false,
+      pinned: false,
+      cookieStoreId: "firefox-container-2",
+    });
+
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      url: "https://example.com",
+      cookieStoreId: "firefox-container-2",
+    });
+  });
+
+  it("rejects an unknown container", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "open-tab",
+      url: "https://example.com",
+      container: "Unknown",
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.contextualIdentities.query as jest.Mock).mockResolvedValue([
+      {
+        cookieStoreId: "firefox-container-2",
+        name: "Work",
+        color: "blue",
+        colorCode: "#37adff",
+        icon: "briefcase",
+      },
+    ]);
+
+    await expect(messageHandler.handleDecodedMessage(request)).rejects.toThrow(
+      'Unknown container "Unknown"'
+    );
+  });
+
+  it("rejects an ambiguous container name", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "open-tab",
+      url: "https://example.com",
+      container: "work",
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.contextualIdentities.query as jest.Mock).mockResolvedValue([
+      {
+        cookieStoreId: "firefox-container-2",
+        name: "Work",
+        color: "blue",
+        colorCode: "#37adff",
+        icon: "briefcase",
+      },
+      {
+        cookieStoreId: "firefox-container-3",
+        name: "WORK",
+        color: "green",
+        colorCode: "#51cd00",
+        icon: "circle",
+      },
+    ]);
+
+    await expect(messageHandler.handleDecodedMessage(request)).rejects.toThrow(
+      'Container name "work" is ambiguous'
+    );
+  });
+
+  it("returns container-enriched tabs", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "get-tab-list",
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.tabs.query as jest.Mock).mockResolvedValue([
+      {
+        id: 123,
+        windowId: 2,
+        index: 4,
+        url: "https://example.com",
+        title: "Example",
+        active: false,
+        pinned: true,
+        cookieStoreId: "firefox-container-2",
+      },
+      {
+        id: 124,
+        windowId: 2,
+        index: 5,
+        url: "https://mozilla.org",
+        title: "Mozilla",
+        active: true,
+        pinned: false,
+        cookieStoreId: "firefox-default",
+      },
+    ]);
+    (browser.contextualIdentities.query as jest.Mock).mockResolvedValue([
+      {
+        cookieStoreId: "firefox-container-2",
+        name: "Work",
+        color: "blue",
+        colorCode: "#37adff",
+        icon: "briefcase",
+      },
+    ]);
+
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "tabs",
+      correlationId: "test-correlation-id",
+      tabs: [
+        expect.objectContaining({
+          id: 123,
+          cookieStoreId: "firefox-container-2",
+          container: expect.objectContaining({
+            name: "Work",
+            cookieStoreId: "firefox-container-2",
+          }),
+        }),
+        expect.objectContaining({
+          id: 124,
+          cookieStoreId: "firefox-default",
+          container: null,
+        }),
+      ],
+    });
+  });
+
+  it("activates a tab and focuses its window", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "activate-tab",
+      tabId: 123,
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.tabs.update as jest.Mock).mockResolvedValue({
+      id: 123,
+      windowId: 7,
+      index: 1,
+      url: "https://example.com",
+      title: "Example",
+      active: true,
+      pinned: false,
+      cookieStoreId: "firefox-default",
+    });
+    (browser.tabs.get as jest.Mock).mockResolvedValue({
+      id: 123,
+      url: "https://example.com",
+    });
+
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(browser.tabs.update).toHaveBeenCalledWith(123, { active: true });
+    expect(browser.windows.update).toHaveBeenCalledWith(7, { focused: true });
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: "activated-tab",
+        correlationId: "test-correlation-id",
+        tabId: 123,
+        windowId: 7,
+      })
+    );
+  });
+
+  it("lists containers in a stable shape", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "get-container-list",
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.contextualIdentities.query as jest.Mock).mockResolvedValue([
+      {
+        cookieStoreId: "firefox-container-2",
+        name: "Work",
+        color: "blue",
+        colorCode: "#37adff",
+        icon: "briefcase",
+      },
+      {
+        cookieStoreId: "firefox-container-3",
+        name: "Personal",
+        color: "green",
+        colorCode: "#51cd00",
+        icon: "circle",
+      },
+    ]);
+
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "containers",
+      correlationId: "test-correlation-id",
+      containers: [
+        {
+          cookieStoreId: "firefox-container-3",
+          name: "Personal",
+          color: "green",
+          colorCode: "#51cd00",
+          icon: "circle",
+        },
+        {
+          cookieStoreId: "firefox-container-2",
+          name: "Work",
+          color: "blue",
+          colorCode: "#37adff",
+          icon: "briefcase",
+        },
+      ],
+    });
+  });
+
+  it("rejects disabled commands for new tools", async () => {
+    const disabledConfig: ExtensionConfig = {
+      secret: "test-secret",
+      toolSettings: {
+        "open-browser-tab": true,
+        "close-browser-tabs": true,
+        "get-list-of-open-tabs": true,
+        "activate-browser-tab": false,
+        "list-browser-containers": true,
+        "get-recent-browser-history": true,
+        "get-tab-web-content": true,
+        "reorder-browser-tabs": true,
+        "find-highlight-in-browser-tab": true,
+      },
+      domainDenyList: [],
+      ports: [8089],
+      auditLog: [],
+    };
+    (browser.storage.local.get as jest.Mock).mockResolvedValue({
+      config: disabledConfig,
+    });
+
+    const request: ServerMessageRequest = {
+      cmd: "activate-tab",
+      tabId: 123,
+      correlationId: "test-correlation-id",
+    };
+
+    await expect(messageHandler.handleDecodedMessage(request)).rejects.toThrow(
+      "Command 'activate-tab' is disabled in extension settings"
+    );
+  });
+
+  it("keeps rejecting non-https tab URLs", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "open-tab",
+      url: "http://example.com",
+      correlationId: "test-correlation-id",
+    };
+
+    await expect(messageHandler.handleDecodedMessage(request)).rejects.toThrow(
+      "Invalid URL"
+    );
+    expect(browser.tabs.create).not.toHaveBeenCalled();
+  });
+
+  it("keeps rejecting deny-listed domains when opening tabs", async () => {
+    (browser.storage.local.get as jest.Mock).mockResolvedValue({
+      config: {
         secret: "test-secret",
         toolSettings: {
-          "open-browser-tab": false, // Disable open-tab command
+          "open-browser-tab": true,
           "close-browser-tabs": true,
           "get-list-of-open-tabs": true,
+          "activate-browser-tab": true,
+          "list-browser-containers": true,
           "get-recent-browser-history": true,
           "get-tab-web-content": true,
           "reorder-browser-tabs": true,
           "find-highlight-in-browser-tab": true,
         },
-        domainDenyList: [],
+        domainDenyList: ["example.com"],
         ports: [8089],
         auditLog: [],
-      };
-      (browser.storage.local.get as jest.Mock).mockResolvedValue({
-        config: configWithDisabledOpenTab,
-      });
-
-      const request: ServerMessageRequest = {
-        cmd: "open-tab",
-        url: "https://example.com",
-        correlationId: "test-correlation-id",
-      };
-
-      // Act & Assert
-      await expect(
-        messageHandler.handleDecodedMessage(request)
-      ).rejects.toThrow("Command 'open-tab' is disabled in extension settings");
+      },
     });
 
-    describe("open-tab command", () => {
-      it("should open a new tab and send the tab ID to the server", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "open-tab",
-          url: "https://example.com",
-          correlationId: "test-correlation-id",
-        };
+    const request: ServerMessageRequest = {
+      cmd: "open-tab",
+      url: "https://example.com",
+      correlationId: "test-correlation-id",
+    };
 
-        const mockTab = { id: 123 };
-        (browser.tabs.create as jest.Mock).mockResolvedValue(mockTab);
+    await expect(messageHandler.handleDecodedMessage(request)).rejects.toThrow(
+      "Domain in user defined deny list"
+    );
+    expect(browser.tabs.create).not.toHaveBeenCalled();
+  });
 
-        // Act
-        await messageHandler.handleDecodedMessage(request);
+  it("closes tabs by id", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "close-tabs",
+      tabIds: [123, 456],
+      correlationId: "test-correlation-id",
+    };
 
-        // Assert
-        expect(browser.tabs.create).toHaveBeenCalledWith({
-          url: "https://example.com",
-        });
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "opened-tab-id",
-          correlationId: "test-correlation-id",
-          tabId: 123,
-        });
-      });
+    await messageHandler.handleDecodedMessage(request);
 
-      it("should throw an error if URL does not start with https://", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "open-tab",
-          url: "http://example.com",
-          correlationId: "test-correlation-id",
-        };
+    expect(browser.tabs.remove).toHaveBeenCalledWith([123, 456]);
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "tabs-closed",
+      correlationId: "test-correlation-id",
+    });
+  });
 
-        // Act & Assert
-        await expect(
-          messageHandler.handleDecodedMessage(request)
-        ).rejects.toThrow("Invalid URL");
-        expect(browser.tabs.create).not.toHaveBeenCalled();
-      });
+  it("searches browser history and filters entries without URLs", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "get-browser-recent-history",
+      searchQuery: "test",
+      correlationId: "test-correlation-id",
+    };
 
-      it("should throw an error if domain is in deny list", async () => {
-        // Arrange
-        const configWithDenyList: ExtensionConfig = {
-          secret: "test-secret",
-          toolSettings: {
-            "open-browser-tab": true,
-            "close-browser-tabs": true,
-            "get-list-of-open-tabs": true,
-            "get-recent-browser-history": true,
-            "get-tab-web-content": true,
-            "reorder-browser-tabs": true,
-            "find-highlight-in-browser-tab": true,
-          },
-          domainDenyList: ["example.com", "another.com"],
-          ports: [8089],
-          auditLog: [],
-        };
-        (browser.storage.local.get as jest.Mock).mockResolvedValue({
-          config: configWithDenyList,
-        });
+    (browser.history.search as jest.Mock).mockResolvedValue([
+      { url: "https://example.com", title: "Example" },
+      { title: "No URL" },
+    ]);
 
-        const request: ServerMessageRequest = {
-          cmd: "open-tab",
-          url: "https://example.com",
-          correlationId: "test-correlation-id",
-        };
+    await messageHandler.handleDecodedMessage(request);
 
-        // Act & Assert
-        await expect(
-          messageHandler.handleDecodedMessage(request)
-        ).rejects.toThrow("Domain in user defined deny list");
-        expect(browser.tabs.create).not.toHaveBeenCalled();
-      });
+    expect(browser.history.search).toHaveBeenCalledWith({
+      text: "test",
+      maxResults: 200,
+      startTime: 0,
+    });
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "history",
+      correlationId: "test-correlation-id",
+      historyItems: [{ url: "https://example.com", title: "Example" }],
+    });
+  });
 
-      it("should open a new tab in the domain is not in the deny list", async () => {
-        // Arrange
-        const configWithDenyList: ExtensionConfig = {
-          secret: "test-secret",
-          toolSettings: {
-            "open-browser-tab": true,
-            "close-browser-tabs": true,
-            "get-list-of-open-tabs": true,
-            "get-recent-browser-history": true,
-            "get-tab-web-content": true,
-            "reorder-browser-tabs": true,
-            "find-highlight-in-browser-tab": true,
-          },
-          domainDenyList: ["example.com", "another.com"],
-          ports: [8089],
-          auditLog: [],
-        };
-        (browser.storage.local.get as jest.Mock).mockResolvedValue({
-          config: configWithDenyList,
-        });
+  it("uses an empty history query by default", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "get-browser-recent-history",
+      correlationId: "test-correlation-id",
+    };
 
-        const request: ServerMessageRequest = {
-          cmd: "open-tab",
-          url: "https://allowed.com",
-          correlationId: "test-correlation-id",
-        };
+    (browser.history.search as jest.Mock).mockResolvedValue([]);
 
-        const mockTab = { id: 123 };
-        (browser.tabs.create as jest.Mock).mockResolvedValue(mockTab);
+    await messageHandler.handleDecodedMessage(request);
 
-        // Act
-        await messageHandler.handleDecodedMessage(request);
+    expect(browser.history.search).toHaveBeenCalledWith({
+      text: "",
+      maxResults: 200,
+      startTime: 0,
+    });
+  });
 
-        // Assert
-        expect(browser.tabs.create).toHaveBeenCalledWith({
-          url: "https://allowed.com",
-        });
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "opened-tab-id",
-          correlationId: "test-correlation-id",
-          tabId: 123,
-        });
-      });
+  it("gets tab web content after URL permission is granted", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "get-tab-content",
+      tabId: 123,
+      correlationId: "test-correlation-id",
+    };
+
+    (browser.tabs.get as jest.Mock).mockResolvedValue({
+      id: 123,
+      url: "https://example.com",
+    });
+    (browser.permissions.contains as jest.Mock).mockResolvedValue(true);
+    (browser.tabs.executeScript as jest.Mock).mockResolvedValue([
+      {
+        links: [{ url: "https://example.com/page", text: "Page" }],
+        fullText: "Page content",
+        isTruncated: false,
+        totalLength: 12,
+      },
+    ]);
+
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(browser.permissions.contains).toHaveBeenCalledWith({
+      origins: ["https://example.com/*"],
+    });
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "tab-content",
+      tabId: 123,
+      correlationId: "test-correlation-id",
+      isTruncated: false,
+      fullText: "Page content",
+      links: [{ url: "https://example.com/page", text: "Page" }],
+      totalLength: 12,
+    });
+  });
+
+  it("rejects tab web content for deny-listed domains", async () => {
+    (browser.storage.local.get as jest.Mock).mockResolvedValue({
+      config: {
+        secret: "test-secret",
+        toolSettings: {
+          "open-browser-tab": true,
+          "close-browser-tabs": true,
+          "get-list-of-open-tabs": true,
+          "activate-browser-tab": true,
+          "list-browser-containers": true,
+          "get-recent-browser-history": true,
+          "get-tab-web-content": true,
+          "reorder-browser-tabs": true,
+          "find-highlight-in-browser-tab": true,
+        },
+        domainDenyList: ["example.com"],
+        ports: [8089],
+        auditLog: [],
+      },
+    });
+    (browser.tabs.get as jest.Mock).mockResolvedValue({
+      id: 123,
+      url: "https://example.com",
     });
 
-    describe("close-tabs command", () => {
-      it("should close tabs and send confirmation to the server", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "close-tabs",
-          tabIds: [123, 456],
-          correlationId: "test-correlation-id",
-        };
+    const request: ServerMessageRequest = {
+      cmd: "get-tab-content",
+      tabId: 123,
+      correlationId: "test-correlation-id",
+    };
 
-        (browser.tabs.remove as jest.Mock).mockResolvedValue(undefined);
+    await expect(messageHandler.handleDecodedMessage(request)).rejects.toThrow(
+      "Domain in tab URL is in the deny list"
+    );
+    expect(browser.tabs.executeScript).not.toHaveBeenCalled();
+  });
 
-        // Act
-        await messageHandler.handleDecodedMessage(request);
+  it("reorders tabs by requested order", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "reorder-tabs",
+      tabOrder: [123, 456, 789],
+      correlationId: "test-correlation-id",
+    };
 
-        // Assert
-        expect(browser.tabs.remove).toHaveBeenCalledWith([123, 456]);
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "tabs-closed",
-          correlationId: "test-correlation-id",
-        });
-      });
+    await messageHandler.handleDecodedMessage(request);
+
+    expect(browser.tabs.move).toHaveBeenCalledTimes(3);
+    expect(browser.tabs.move).toHaveBeenNthCalledWith(1, 123, { index: 0 });
+    expect(browser.tabs.move).toHaveBeenNthCalledWith(2, 456, { index: 1 });
+    expect(browser.tabs.move).toHaveBeenNthCalledWith(3, 789, { index: 2 });
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "tabs-reordered",
+      correlationId: "test-correlation-id",
+      tabOrder: [123, 456, 789],
     });
+  });
 
-    describe("get-tab-list command", () => {
-      it("should get tabs and send them to the server", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "get-tab-list",
-          correlationId: "test-correlation-id",
-        };
+  it("finds and highlights matching text in a tab", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "find-highlight",
+      tabId: 123,
+      queryPhrase: "test",
+      correlationId: "test-correlation-id",
+    };
 
-        const mockTabs = [{ id: 123, url: "https://example.com" }];
-        (browser.tabs.query as jest.Mock).mockResolvedValue(mockTabs);
-
-        // Act
-        await messageHandler.handleDecodedMessage(request);
-
-        // Assert
-        expect(browser.tabs.query).toHaveBeenCalledWith({});
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "tabs",
-          correlationId: "test-correlation-id",
-          tabs: mockTabs,
-        });
-      });
+    (browser.tabs.get as jest.Mock).mockResolvedValue({
+      id: 123,
+      url: "https://example.com",
     });
+    (browser.permissions.contains as jest.Mock).mockResolvedValue(true);
+    (browser.find.find as jest.Mock).mockResolvedValue({ count: 5 });
 
-    describe("get-browser-recent-history command", () => {
-      it("should get history items and send them to the server", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "get-browser-recent-history",
-          searchQuery: "test",
-          correlationId: "test-correlation-id",
-        };
+    await messageHandler.handleDecodedMessage(request);
 
-        const mockHistoryItems = [
-          { url: "https://example.com", title: "Example" },
-          { url: "https://test.com", title: "Test" },
-        ];
-        (browser.history.search as jest.Mock).mockResolvedValue(
-          mockHistoryItems
-        );
-
-        // Act
-        await messageHandler.handleDecodedMessage(request);
-
-        // Assert
-        expect(browser.history.search).toHaveBeenCalledWith({
-          text: "test",
-          maxResults: 200,
-          startTime: 0,
-        });
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "history",
-          correlationId: "test-correlation-id",
-          historyItems: mockHistoryItems,
-        });
-      });
-
-      it("should use empty string for search query if not provided", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "get-browser-recent-history",
-          correlationId: "test-correlation-id",
-        };
-
-        const mockHistoryItems = [
-          { url: "https://example.com", title: "Example" },
-        ];
-        (browser.history.search as jest.Mock).mockResolvedValue(
-          mockHistoryItems
-        );
-
-        // Act
-        await messageHandler.handleDecodedMessage(request);
-
-        // Assert
-        expect(browser.history.search).toHaveBeenCalledWith({
-          text: "",
-          maxResults: 200,
-          startTime: 0,
-        });
-      });
-
-      it("should filter out history items without URLs", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "get-browser-recent-history",
-          correlationId: "test-correlation-id",
-        };
-
-        const mockHistoryItems = [
-          { url: "https://example.com", title: "Example" },
-          { title: "No URL" }, // This should be filtered out
-        ];
-        (browser.history.search as jest.Mock).mockResolvedValue(
-          mockHistoryItems
-        );
-
-        // Act
-        await messageHandler.handleDecodedMessage(request);
-
-        // Assert
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "history",
-          correlationId: "test-correlation-id",
-          historyItems: [{ url: "https://example.com", title: "Example" }],
-        });
-      });
+    expect(browser.find.find).toHaveBeenCalledWith("test", {
+      tabId: 123,
+      caseSensitive: true,
     });
-
-    describe("get-tab-content command", () => {
-      it("should get tab content and send it to the server", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "get-tab-content",
-          tabId: 123,
-          correlationId: "test-correlation-id",
-        };
-
-        const mockTab = { id: 123, url: "https://example.com" };
-        (browser.tabs.get as jest.Mock).mockResolvedValue(mockTab);
-        (browser.permissions.contains as jest.Mock).mockResolvedValue(true);
-
-        const mockScriptResult = [
-          {
-            links: [{ url: "https://example.com/page", text: "Page" }],
-            fullText: "Page content",
-            isTruncated: false,
-            totalLength: 12,
-          },
-        ];
-        (browser.tabs.executeScript as jest.Mock).mockResolvedValue(
-          mockScriptResult
-        );
-
-        // Act
-        await messageHandler.handleDecodedMessage(request);
-
-        // Assert
-        expect(browser.tabs.get).toHaveBeenCalledWith(123);
-        expect(browser.permissions.contains).toHaveBeenCalledWith({
-          origins: ["https://example.com/*"],
-        });
-        expect(browser.tabs.executeScript).toHaveBeenCalled();
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "tab-content",
-          tabId: 123,
-          correlationId: "test-correlation-id",
-          isTruncated: false,
-          fullText: "Page content",
-          links: [{ url: "https://example.com/page", text: "Page" }],
-          totalLength: 12,
-        });
-      });
-
-      it("should throw an error if tab URL domain is in deny list", async () => {
-        // Arrange
-        const configWithDenyList: ExtensionConfig = {
-          secret: "test-secret",
-          toolSettings: {
-            "open-browser-tab": true,
-            "close-browser-tabs": true,
-            "get-list-of-open-tabs": true,
-            "get-recent-browser-history": true,
-            "get-tab-web-content": true,
-            "reorder-browser-tabs": true,
-            "find-highlight-in-browser-tab": true,
-          },
-          domainDenyList: ["example.com"], // Add example.com to deny list
-          ports: [8089],
-          auditLog: [],
-        };
-        (browser.storage.local.get as jest.Mock).mockResolvedValue({
-          config: configWithDenyList,
-        });
-
-        const request: ServerMessageRequest = {
-          cmd: "get-tab-content",
-          tabId: 123,
-          correlationId: "test-correlation-id",
-        };
-
-        const mockTab = { id: 123, url: "https://example.com" };
-        (browser.tabs.get as jest.Mock).mockResolvedValue(mockTab);
-
-        // Act & Assert
-        await expect(
-          messageHandler.handleDecodedMessage(request)
-        ).rejects.toThrow("Domain in tab URL is in the deny list");
-        expect(browser.tabs.executeScript).not.toHaveBeenCalled();
-      });
-
-      it("should throw an error if permissions are denied", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "get-tab-content",
-          tabId: 123,
-          correlationId: "test-correlation-id",
-        };
-
-        const mockTab = { id: 123, url: "https://example.com" };
-        (browser.tabs.get as jest.Mock).mockResolvedValue(mockTab);
-        (browser.permissions.contains as jest.Mock).mockResolvedValue(false);
-
-        // Act & Assert
-        await expect(
-          messageHandler.handleDecodedMessage(request)
-        ).rejects.toThrow();
-        expect(browser.tabs.executeScript).not.toHaveBeenCalled();
-      });
+    expect(browser.tabs.update).toHaveBeenCalledWith(123, { active: true });
+    expect(browser.find.highlightResults).toHaveBeenCalledWith({
+      tabId: 123,
     });
-
-    describe("reorder-tabs command", () => {
-      it("should reorder tabs and send confirmation to the server", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "reorder-tabs",
-          tabOrder: [123, 456, 789],
-          correlationId: "test-correlation-id",
-        };
-
-        (browser.tabs.move as jest.Mock).mockResolvedValue(undefined);
-
-        // Act
-        await messageHandler.handleDecodedMessage(request);
-
-        // Assert
-        expect(browser.tabs.move).toHaveBeenCalledTimes(3);
-        expect(browser.tabs.move).toHaveBeenNthCalledWith(1, 123, { index: 0 });
-        expect(browser.tabs.move).toHaveBeenNthCalledWith(2, 456, { index: 1 });
-        expect(browser.tabs.move).toHaveBeenNthCalledWith(3, 789, { index: 2 });
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "tabs-reordered",
-          correlationId: "test-correlation-id",
-          tabOrder: [123, 456, 789],
-        });
-      });
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "find-highlight-result",
+      correlationId: "test-correlation-id",
+      noOfResults: 5,
     });
+  });
 
-    describe("find-highlight command", () => {
-      it("should find and highlight text in a tab", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "find-highlight",
-          tabId: 123,
-          queryPhrase: "test",
-          correlationId: "test-correlation-id",
-        };
+  it("does not activate or highlight when text is absent", async () => {
+    const request: ServerMessageRequest = {
+      cmd: "find-highlight",
+      tabId: 123,
+      queryPhrase: "test",
+      correlationId: "test-correlation-id",
+    };
 
-        const mockFindResults = { count: 5 };
-        (browser.find.find as jest.Mock).mockResolvedValue(mockFindResults);
-        (browser.tabs.update as jest.Mock).mockResolvedValue(undefined);
-        (browser.permissions.contains as jest.Mock).mockResolvedValue(true);
+    (browser.tabs.get as jest.Mock).mockResolvedValue({
+      id: 123,
+      url: "https://example.com",
+    });
+    (browser.permissions.contains as jest.Mock).mockResolvedValue(true);
+    (browser.find.find as jest.Mock).mockResolvedValue({ count: 0 });
 
-        // Act
-        await messageHandler.handleDecodedMessage(request);
+    await messageHandler.handleDecodedMessage(request);
 
-        // Assert
-        expect(browser.find.find).toHaveBeenCalledWith("test", {
-          tabId: 123,
-          caseSensitive: true,
-        });
-        expect(browser.tabs.update).toHaveBeenCalledWith(123, { active: true });
-        expect(browser.find.highlightResults).toHaveBeenCalledWith({
-          tabId: 123,
-        });
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "find-highlight-result",
-          correlationId: "test-correlation-id",
-          noOfResults: 5,
-        });
-      });
-
-      it("should not highlight or activate tab if no results found", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "find-highlight",
-          tabId: 123,
-          queryPhrase: "test",
-          correlationId: "test-correlation-id",
-        };
-
-        const mockFindResults = { count: 0 };
-        const mockTab = { id: 123, url: "https://example.com" };
-        (browser.tabs.get as jest.Mock).mockResolvedValue(mockTab);
-        (browser.find.find as jest.Mock).mockResolvedValue(mockFindResults);
-        (browser.permissions.contains as jest.Mock).mockResolvedValue(true);
-
-        // Act
-        await messageHandler.handleDecodedMessage(request);
-
-        // Assert
-        expect(browser.tabs.update).not.toHaveBeenCalled();
-        expect(browser.find.highlightResults).not.toHaveBeenCalled();
-        expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
-          resource: "find-highlight-result",
-          correlationId: "test-correlation-id",
-          noOfResults: 0,
-        });
-      });
-
-      it("should throw an error if permissions are denied", async () => {
-        // Arrange
-        const request: ServerMessageRequest = {
-          cmd: "find-highlight",
-          tabId: 123,
-          queryPhrase: "test",
-          correlationId: "test-correlation-id",
-        };
-
-        const mockTab = { id: 123, url: "https://example.com" };
-        (browser.tabs.get as jest.Mock).mockResolvedValue(mockTab);
-        (browser.permissions.contains as jest.Mock).mockResolvedValue(false);
-
-        // Act & Assert
-        await expect(
-          messageHandler.handleDecodedMessage(request)
-        ).rejects.toThrow();
-        expect(browser.find.find).not.toHaveBeenCalled();
-      });
+    expect(browser.tabs.update).not.toHaveBeenCalled();
+    expect(browser.find.highlightResults).not.toHaveBeenCalled();
+    expect(mockClient.sendResourceToServer).toHaveBeenCalledWith({
+      resource: "find-highlight-result",
+      correlationId: "test-correlation-id",
+      noOfResults: 0,
     });
   });
 });

--- a/firefox-extension/__tests__/setup.ts
+++ b/firefox-extension/__tests__/setup.ts
@@ -12,8 +12,14 @@ const mockBrowser = {
     update: jest.fn(),
     group: jest.fn(),
   },
+  windows: {
+    update: jest.fn(),
+  },
   tabGroups: {
     update: jest.fn(),
+  },
+  contextualIdentities: {
+    query: jest.fn(),
   },
   history: {
     search: jest.fn(),
@@ -24,8 +30,8 @@ const mockBrowser = {
   },
   storage: {
     local: {
-        get: jest.fn(),
-        set: jest.fn(),
+      get: jest.fn(),
+      set: jest.fn(),
     },
   },
   permissions: {
@@ -37,7 +43,7 @@ const mockBrowser = {
 };
 
 // Override the global browser object
-Object.defineProperty(global, 'browser', {
+Object.defineProperty(global, "browser", {
   value: mockBrowser,
   writable: true,
   configurable: true,

--- a/firefox-extension/extension-config.ts
+++ b/firefox-extension/extension-config.ts
@@ -31,6 +31,16 @@ export const AVAILABLE_TOOLS: ToolInfo[] = [
     description: "Allows the MCP server to get a list of all open tabs"
   },
   {
+    id: "activate-browser-tab",
+    name: "Activate Browser Tab",
+    description: "Allows the MCP server to activate a tab and focus its window"
+  },
+  {
+    id: "list-browser-containers",
+    name: "List Browser Containers",
+    description: "Allows the MCP server to list Firefox containers and their IDs"
+  },
+  {
     id: "get-recent-browser-history",
     name: "Get Recent Browser History",
     description: "Allows the MCP server to access your recent browsing history"
@@ -57,6 +67,8 @@ export const COMMAND_TO_TOOL_ID: Record<ServerMessageRequest["cmd"], string> = {
   "open-tab": "open-browser-tab",
   "close-tabs": "close-browser-tabs",
   "get-tab-list": "get-list-of-open-tabs",
+  "activate-tab": "activate-browser-tab",
+  "get-container-list": "list-browser-containers",
   "get-browser-recent-history": "get-recent-browser-history",
   "get-tab-content": "get-tab-web-content",
   "reorder-tabs": "reorder-browser-tabs",

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -7,7 +7,9 @@
         "tabs",
         "tabGroups",
         "history",
-        "storage"
+        "storage",
+        "contextualIdentities",
+        "cookies"
     ],
     "optional_permissions": [
         "*://*/*",

--- a/firefox-extension/message-handler.ts
+++ b/firefox-extension/message-handler.ts
@@ -1,6 +1,17 @@
-import type { ServerMessageRequest } from "@browser-control-mcp/common";
+import type {
+  BrowserContainer,
+  BrowserTab,
+  ServerMessageRequest,
+} from "@browser-control-mcp/common";
 import { WebsocketClient } from "./client";
-import { isCommandAllowed, isDomainInDenyList, COMMAND_TO_TOOL_ID, addAuditLogEntry } from "./extension-config";
+import {
+  isCommandAllowed,
+  isDomainInDenyList,
+  COMMAND_TO_TOOL_ID,
+  addAuditLogEntry,
+} from "./extension-config";
+
+const DEFAULT_CONTAINER_NAME = "default";
 
 export class MessageHandler {
   private client: WebsocketClient;
@@ -21,13 +32,19 @@ export class MessageHandler {
 
     switch (req.cmd) {
       case "open-tab":
-        await this.openUrl(req.correlationId, req.url);
+        await this.openUrl(req.correlationId, req.url, req.container);
         break;
       case "close-tabs":
         await this.closeTabs(req.correlationId, req.tabIds);
         break;
       case "get-tab-list":
         await this.sendTabs(req.correlationId);
+        break;
+      case "activate-tab":
+        await this.activateTab(req.correlationId, req.tabId);
+        break;
+      case "get-container-list":
+        await this.sendContainers(req.correlationId);
         break;
       case "get-browser-recent-history":
         await this.sendRecentHistory(req.correlationId, req.searchQuery);
@@ -61,7 +78,6 @@ export class MessageHandler {
   }
 
   private async addAuditLogForReq(req: ServerMessageRequest) {
-    // Get the URL in context (either from param or from the tab)
     let contextUrl: string | undefined;
     if ("url" in req && req.url) {
       contextUrl = req.url;
@@ -80,13 +96,17 @@ export class MessageHandler {
       toolId,
       command: req.cmd,
       timestamp: Date.now(),
-      url: contextUrl
+      url: contextUrl,
     };
-    
+
     await addAuditLogEntry(auditEntry);
   }
 
-  private async openUrl(correlationId: string, url: string): Promise<void> {
+  private async openUrl(
+    correlationId: string,
+    url: string,
+    container?: string
+  ): Promise<void> {
     if (!url.startsWith("https://")) {
       console.error("Invalid URL:", url);
       throw new Error("Invalid URL");
@@ -96,14 +116,19 @@ export class MessageHandler {
       throw new Error("Domain in user defined deny list");
     }
 
+    const cookieStoreId = await this.resolveRequestedContainer(container);
     const tab = await browser.tabs.create({
       url,
+      ...(cookieStoreId ? { cookieStoreId } : {}),
     });
+    const containerMap = await this.getContainerMap();
+    const tabDetails = this.mapBrowserTab(tab, containerMap);
 
     await this.client.sendResourceToServer({
       resource: "opened-tab-id",
       correlationId,
       tabId: tab.id,
+      tab: tabDetails,
     });
   }
 
@@ -120,10 +145,40 @@ export class MessageHandler {
 
   private async sendTabs(correlationId: string): Promise<void> {
     const tabs = await browser.tabs.query({});
+    const containerMap = await this.getContainerMap();
+    const mappedTabs = tabs.map((tab) => this.mapBrowserTab(tab, containerMap));
     await this.client.sendResourceToServer({
       resource: "tabs",
       correlationId,
-      tabs,
+      tabs: mappedTabs,
+    });
+  }
+
+  private async activateTab(
+    correlationId: string,
+    tabId: number
+  ): Promise<void> {
+    const activatedTab = await browser.tabs.update(tabId, { active: true });
+    if (activatedTab.windowId !== undefined) {
+      await browser.windows.update(activatedTab.windowId, { focused: true });
+    }
+    const containerMap = await this.getContainerMap();
+    const tabDetails = this.mapBrowserTab(activatedTab, containerMap);
+    await this.client.sendResourceToServer({
+      resource: "activated-tab",
+      correlationId,
+      tabId: activatedTab.id,
+      windowId: activatedTab.windowId,
+      tab: tabDetails,
+    });
+  }
+
+  private async sendContainers(correlationId: string): Promise<void> {
+    const containers = await this.getContainers();
+    await this.client.sendResourceToServer({
+      resource: "containers",
+      correlationId,
+      containers,
     });
   }
 
@@ -132,9 +187,9 @@ export class MessageHandler {
     searchQuery: string | null = null
   ): Promise<void> {
     const historyItems = await browser.history.search({
-      text: searchQuery ?? "", // Search for all URLs (empty string matches everything)
-      maxResults: 200, // Limit to 200 results
-      startTime: 0, // Search from the beginning of time
+      text: searchQuery ?? "",
+      maxResults: 200,
+      startTime: 0,
     });
     const filteredHistoryItems = historyItems.filter((item) => {
       return !!item.url;
@@ -146,9 +201,6 @@ export class MessageHandler {
     });
   }
 
-  // Check that the user has granted permission to access the URL's domain.
-  // This will open the options page with a URL parameter to request permission
-  // and throw an error to indicate that the request cannot proceed until permission is granted.
   private async checkForUrlPermission(url: string | undefined): Promise<void> {
     if (url) {
       const origin = new URL(url).origin;
@@ -157,7 +209,6 @@ export class MessageHandler {
       });
 
       if (!granted) {
-        // Open the options page with a URL parameter to request permission:
         const optionsUrl = browser.runtime.getURL("options.html");
         const urlWithParams = `${optionsUrl}?requestUrl=${encodeURIComponent(
           url
@@ -177,7 +228,6 @@ export class MessageHandler {
     });
 
     if (!granted) {
-      // Open the options page with a URL parameter to request permission:
       const optionsUrl = browser.runtime.getURL("options.html");
       const urlWithParams = `${optionsUrl}?requestPermissions=${encodeURIComponent(
         JSON.stringify(permissions)
@@ -255,7 +305,6 @@ export class MessageHandler {
     correlationId: string,
     tabOrder: number[]
   ): Promise<void> {
-    // Reorder the tabs sequentially
     for (let newIndex = 0; newIndex < tabOrder.length; newIndex++) {
       const tabId = tabOrder[newIndex];
       await browser.tabs.move(tabId, { index: newIndex });
@@ -285,10 +334,7 @@ export class MessageHandler {
       caseSensitive: true,
     });
 
-    // If there are results, highlight them
     if (findResults.count > 0) {
-      // But first, activate the tab. In firefox, this would also enable
-      // auto-scrolling to the highlighted result.
       await browser.tabs.update(tabId, { active: true });
       browser.find.highlightResults({
         tabId,
@@ -313,7 +359,7 @@ export class MessageHandler {
       tabIds,
     });
 
-    let tabGroup = await browser.tabGroups.update(groupId, {
+    const tabGroup = await browser.tabGroups.update(groupId, {
       collapsed: isCollapsed,
       color: groupColor,
       title: groupTitle,
@@ -324,5 +370,105 @@ export class MessageHandler {
       correlationId,
       groupId: tabGroup.id,
     });
+  }
+
+  private async getContainers(): Promise<BrowserContainer[]> {
+    const identities = await browser.contextualIdentities.query({});
+    return identities
+      .map((identity) => ({
+        cookieStoreId: identity.cookieStoreId,
+        name: identity.name,
+        color: identity.color,
+        colorCode: identity.colorCode,
+        icon: identity.icon,
+      }))
+      .sort((a, b) => {
+        const byName = a.name.localeCompare(b.name);
+        if (byName !== 0) {
+          return byName;
+        }
+        return a.cookieStoreId.localeCompare(b.cookieStoreId);
+      });
+  }
+
+  private mapBrowserTab(
+    tab: browser.tabs.Tab,
+    containerMap: Map<string, BrowserContainer>
+  ): BrowserTab {
+    return {
+      id: tab.id,
+      windowId: tab.windowId,
+      index: tab.index,
+      url: tab.url,
+      title: tab.title,
+      lastAccessed: tab.lastAccessed,
+      active: tab.active,
+      pinned: tab.pinned,
+      cookieStoreId: tab.cookieStoreId,
+      container:
+        tab.cookieStoreId && !this.isDefaultCookieStore(tab.cookieStoreId)
+          ? (containerMap.get(tab.cookieStoreId) ?? null)
+          : null,
+    };
+  }
+
+  private async getContainerMap(): Promise<Map<string, BrowserContainer>> {
+    const containers = await this.getContainers();
+    return new Map(
+      containers.map((container) => [container.cookieStoreId, container])
+    );
+  }
+
+  private isDefaultCookieStore(cookieStoreId: string): boolean {
+    return cookieStoreId === "firefox-default";
+  }
+
+  private async resolveRequestedContainer(
+    requestedContainer?: string
+  ): Promise<string | undefined> {
+    const candidate = requestedContainer?.trim();
+    if (!candidate || candidate === DEFAULT_CONTAINER_NAME) {
+      return undefined;
+    }
+
+    const containers = await this.getContainers();
+
+    const exactIdMatch = containers.find(
+      (container) => container.cookieStoreId === candidate
+    );
+    if (exactIdMatch) {
+      return exactIdMatch.cookieStoreId;
+    }
+
+    const exactNameMatches = containers.filter(
+      (container) => container.name === candidate
+    );
+    if (exactNameMatches.length === 1) {
+      return exactNameMatches[0].cookieStoreId;
+    }
+    if (exactNameMatches.length > 1) {
+      throw new Error(
+        `Container name "${candidate}" is ambiguous. Use cookieStoreId instead.`
+      );
+    }
+
+    const caseInsensitiveMatches = containers.filter(
+      (container) => container.name.toLowerCase() === candidate.toLowerCase()
+    );
+    if (caseInsensitiveMatches.length === 1) {
+      return caseInsensitiveMatches[0].cookieStoreId;
+    }
+    if (caseInsensitiveMatches.length > 1) {
+      throw new Error(
+        `Container name "${candidate}" is ambiguous. Use cookieStoreId instead.`
+      );
+    }
+
+    const validContainers = containers
+      .map((container) => `${container.name} (${container.cookieStoreId})`)
+      .join(", ");
+    throw new Error(
+      `Unknown container "${candidate}". Valid containers: ${validContainers}`
+    );
   }
 }

--- a/mcp-server/browser-api.ts
+++ b/mcp-server/browser-api.ts
@@ -1,6 +1,7 @@
 import WebSocket from "ws";
 import type {
   ExtensionMessage,
+  BrowserContainer,
   BrowserTab,
   BrowserHistoryItem,
   ServerMessage,
@@ -88,13 +89,20 @@ export class BrowserAPI {
     return this.wsServer?.options.port;
   }
 
-  async openTab(url: string): Promise<number | undefined> {
+  async openTab(
+    url: string,
+    container?: string
+  ): Promise<{ tabId: number | undefined; tab?: BrowserTab }> {
     const correlationId = this.sendMessageToExtension({
       cmd: "open-tab",
       url,
+      container,
     });
     const message = await this.waitForResponse(correlationId, "opened-tab-id");
-    return message.tabId;
+    return {
+      tabId: message.tabId,
+      tab: message.tab,
+    };
   }
 
   async closeTabs(tabIds: number[]) {
@@ -111,6 +119,33 @@ export class BrowserAPI {
     });
     const message = await this.waitForResponse(correlationId, "tabs");
     return message.tabs;
+  }
+
+  async activateTab(
+    tabId: number
+  ): Promise<{
+    tabId: number | undefined;
+    windowId: number | undefined;
+    tab?: BrowserTab;
+  }> {
+    const correlationId = await this.sendMessageToExtension({
+      cmd: "activate-tab",
+      tabId,
+    });
+    const message = await this.waitForResponse(correlationId, "activated-tab");
+    return {
+      tabId: message.tabId,
+      windowId: message.windowId,
+      tab: message.tab,
+    };
+  }
+
+  async getContainerList(): Promise<BrowserContainer[]> {
+    const correlationId = await this.sendMessageToExtension({
+      cmd: "get-container-list",
+    });
+    const message = await this.waitForResponse(correlationId, "containers");
+    return message.containers;
   }
 
   async getBrowserRecentHistory(

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,8 +3,8 @@
     "name": "browser-control-firefox",
     "version": "1.5.1",
     "display_name": "Firefox Control",
-    "description": "Control Mozilla Firefox: tabs, history and web content (privacy aware)",
-    "long_description": "This MCP server provides AI assistants with access to the browser's tab management, browsing history, page search, and webpage text content through a local MCP (Model Context Protocol) connection.\n\nBefore accessing any webpage content, explicit user consent is required for each domain through browser-side permissions.\n\n**Note:** This extension requires a separate Firefox add-on component, which is available at [https://addons.mozilla.org/en-US/firefox/addon/browser-control-mcp/](https://addons.mozilla.org/en-US/firefox/addon/browser-control-mcp/). Start by installing the Firefox add-on, then copy the secret key from the add-on settings page (it will open automatically) and paste it into this extension's configuration.",
+    "description": "Control Mozilla Firefox: tabs, containers, history and web content (privacy aware)",
+    "long_description": "This MCP server provides AI assistants with access to the browser's tab management, Firefox container metadata, browsing history, page search, and webpage text content through a local MCP (Model Context Protocol) connection.\n\nBefore accessing any webpage content, explicit user consent is required for each domain through browser-side permissions.\n\n**Note:** This extension requires a separate Firefox add-on component, which is available at [https://addons.mozilla.org/en-US/firefox/addon/browser-control-mcp/](https://addons.mozilla.org/en-US/firefox/addon/browser-control-mcp/). Start by installing the Firefox add-on, then copy the secret key from the add-on settings page (it will open automatically) and paste it into this extension's configuration.",
     "author": {
         "name": "eyalzh",
         "url": "https://github.com/eyalzh"
@@ -61,7 +61,15 @@
         },
         {
             "name": "get-list-of-open-tabs",
-            "description": "Get the list of open tabs in the browser"
+            "description": "Get the list of open tabs in the browser, including Firefox container metadata"
+        },
+        {
+            "name": "activate-browser-tab",
+            "description": "Activate an open browser tab and focus its window"
+        },
+        {
+            "name": "list-browser-containers",
+            "description": "List Firefox containers and their cookieStoreId values"
         },
         {
             "name": "get-recent-browser-history",

--- a/mcp-server/server.ts
+++ b/mcp-server/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { BrowserAPI } from "./browser-api";
+import type { BrowserContainer, BrowserTab } from "@browser-control-mcp/common";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 
@@ -12,26 +13,101 @@ const mcpServer = new McpServer({
   version: "1.5.1",
 });
 
+const browserApi = new BrowserAPI();
+
+function describeContainer(tab: BrowserTab): string {
+  if (tab.container) {
+    return `${tab.container.name} (${tab.container.cookieStoreId})`;
+  }
+  return "default";
+}
+
+function describeLastAccessed(lastAccessed?: number): string {
+  if (!lastAccessed) {
+    return "unknown";
+  }
+  return dayjs(lastAccessed).fromNow();
+}
+
+function filterTabsByContainer(
+  tabs: BrowserTab[],
+  requestedContainer?: string
+): BrowserTab[] {
+  const candidate = requestedContainer?.trim();
+  if (!candidate) {
+    return tabs;
+  }
+
+  if (candidate === "default") {
+    return tabs.filter(
+      (tab) => tab.container === null || tab.container === undefined
+    );
+  }
+
+  return tabs.filter((tab) => {
+    if (!tab.container) {
+      return false;
+    }
+    return (
+      tab.container.cookieStoreId === candidate ||
+      tab.container.name === candidate ||
+      tab.container.name.toLowerCase() === candidate.toLowerCase()
+    );
+  });
+}
+
+function renderTabLine(tab: BrowserTab): string {
+  return [
+    `tab id=${tab.id}`,
+    `window id=${tab.windowId}`,
+    `index=${tab.index}`,
+    `tab url=${tab.url}`,
+    `tab title=${tab.title}`,
+    `container=${describeContainer(tab)}`,
+    `active=${tab.active ? "yes" : "no"}`,
+    `pinned=${tab.pinned ? "yes" : "no"}`,
+    `last accessed=${describeLastAccessed(tab.lastAccessed)}`,
+  ].join(", ");
+}
+
+function renderContainerLine(container: BrowserContainer): string {
+  return [
+    `container name=${container.name}`,
+    `cookieStoreId=${container.cookieStoreId}`,
+    `color=${container.color}`,
+    `icon=${container.icon}`,
+  ].join(", ");
+}
+
 mcpServer.tool(
   "open-browser-tab",
-  "Open a new tab in the user's browser (useful when the user asks to open a website)",
-  { url: z.string() },
-  async ({ url }) => {
-    const openedTabId = await browserApi.openTab(url);
-    if (openedTabId !== undefined) {
+  "Open a new tab in the user's browser. Optionally choose a Firefox container by exact name or cookieStoreId.",
+  {
+    url: z.string(),
+    container: z.string().optional(),
+  },
+  async ({ url, container }) => {
+    const openedTab = await browserApi.openTab(url, container);
+    if (openedTab.tabId !== undefined) {
+      const details = openedTab.tab
+        ? ` in ${describeContainer(openedTab.tab)}`
+        : "";
       return {
         content: [
           {
             type: "text",
-            text: `${url} opened in tab id ${openedTabId}`,
+            text: `${url} opened in tab id ${openedTab.tabId}${details}`,
           },
         ],
-      };
-    } else {
-      return {
-        content: [{ type: "text", text: "Failed to open tab", isError: true }],
+        structuredContent: {
+          tabId: openedTab.tabId,
+          tab: openedTab.tab ?? null,
+        },
       };
     }
+    return {
+      content: [{ type: "text", text: "Failed to open tab", isError: true }],
+    };
   }
 );
 
@@ -51,39 +127,110 @@ mcpServer.tool(
   "get-list-of-open-tabs",
   "Get the list of open tabs in the user's browser. Use offset and limit parameters for pagination when there are many tabs.",
   {
-    offset: z.number().int().min(0).default(0).describe("Starting index for pagination (0-based, must be >= 0)"),
-    limit: z.number().default(100).describe("Maximum number of tabs to return (default: 100, max: 500)"),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe("Starting index for pagination (0-based, must be >= 0)"),
+    limit: z
+      .number()
+      .default(100)
+      .describe("Maximum number of tabs to return (default: 100, max: 500)"),
+    container: z
+      .string()
+      .optional()
+      .describe("Optional Firefox container name or cookieStoreId filter"),
+    windowId: z
+      .number()
+      .int()
+      .optional()
+      .describe("Optional browser window ID filter"),
+    activeOnly: z
+      .boolean()
+      .default(false)
+      .describe("If true, return only active tabs"),
   },
-  async ({ offset, limit }) => {
-    // Validate and cap the limit
+  async ({ offset, limit, container, windowId, activeOnly }) => {
     const effectiveLimit = Math.min(Math.max(1, limit), 500);
 
-    const openTabs = await browserApi.getTabList();
-    const totalTabs = openTabs.length;
+    let openTabs = await browserApi.getTabList();
+    openTabs = filterTabsByContainer(openTabs, container);
 
-    // Apply pagination
+    if (windowId !== undefined) {
+      openTabs = openTabs.filter((tab) => tab.windowId === windowId);
+    }
+    if (activeOnly) {
+      openTabs = openTabs.filter((tab) => tab.active);
+    }
+
+    const totalTabs = openTabs.length;
     const paginatedTabs = openTabs.slice(offset, offset + effectiveLimit);
     const hasMore = offset + effectiveLimit < totalTabs;
 
-    // Add pagination info as the first content item
     const paginationInfo = {
       type: "text" as const,
-      text: `Showing tabs ${offset + 1}-${offset + paginatedTabs.length} of ${totalTabs} total tabs${hasMore ? ` (use offset=${offset + effectiveLimit} to see more)` : ''}`,
+      text:
+        `Showing tabs ${offset + 1}-${offset + paginatedTabs.length} ` +
+        `of ${totalTabs} total tabs` +
+        (hasMore ? ` (use offset=${offset + effectiveLimit} to see more)` : ""),
     };
 
-    const tabContent = paginatedTabs.map((tab) => {
-      let lastAccessed = "unknown";
-      if (tab.lastAccessed) {
-        lastAccessed = dayjs(tab.lastAccessed).fromNow(); // LLM-friendly time ago
-      }
-      return {
-        type: "text" as const,
-        text: `tab id=${tab.id}, tab url=${tab.url}, tab title=${tab.title}, last accessed=${lastAccessed}`,
-      };
-    });
-
     return {
-      content: [paginationInfo, ...tabContent],
+      content: [
+        paginationInfo,
+        ...paginatedTabs.map((tab) => ({
+          type: "text" as const,
+          text: renderTabLine(tab),
+        })),
+      ],
+      structuredContent: {
+        tabs: paginatedTabs,
+        total: totalTabs,
+        offset,
+        limit: effectiveLimit,
+        hasMore,
+      },
+    };
+  }
+);
+
+mcpServer.tool(
+  "activate-browser-tab",
+  "Activate an open browser tab and focus its window",
+  { tabId: z.number() },
+  async ({ tabId }) => {
+    const activatedTab = await browserApi.activateTab(tabId);
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Activated tab id ${activatedTab.tabId} in window ${activatedTab.windowId}`,
+        },
+      ],
+      structuredContent: {
+        tabId: activatedTab.tabId,
+        windowId: activatedTab.windowId,
+        tab: activatedTab.tab ?? null,
+      },
+    };
+  }
+);
+
+mcpServer.tool(
+  "list-browser-containers",
+  "List Firefox containers with both human names and cookieStoreId values",
+  {},
+  async () => {
+    const containers = await browserApi.getContainerList();
+    return {
+      content: containers.map((container) => ({
+        type: "text" as const,
+        text: renderContainerLine(container),
+      })),
+      structuredContent: {
+        containers,
+      },
     };
   }
 );
@@ -101,27 +248,24 @@ mcpServer.tool(
         content: browserHistory.map((item) => {
           let lastVisited = "unknown";
           if (item.lastVisitTime) {
-            lastVisited = dayjs(item.lastVisitTime).fromNow(); // LLM-friendly time ago
+            lastVisited = dayjs(item.lastVisitTime).fromNow();
           }
           return {
-            type: "text",
+            type: "text" as const,
             text: `url=${item.url}, title="${item.title}", lastVisitTime=${lastVisited}`,
           };
         }),
       };
-    } else {
-      // If nothing was found for the search query, hint the AI to list
-      // all the recent history items instead.
-      const hint = searchQuery ? "Try without a searchQuery" : "";
-      return { content: [{ type: "text", text: `No history found. ${hint}` }] };
     }
+    const hint = searchQuery ? "Try without a searchQuery" : "";
+    return { content: [{ type: "text", text: `No history found. ${hint}` }] };
   }
 );
 
 mcpServer.tool(
   "get-tab-web-content",
   `
-    Get the full text content of the webpage and the list of links in the webpage, by tab ID. 
+    Get the full text content of the webpage and the list of links in the webpage, by tab ID.
     Use "offset" only for larger documents when the first call was truncated and if you require more content in order to assist the user.
   `,
   { tabId: z.number(), offset: z.number().default(0) },
@@ -129,12 +273,9 @@ mcpServer.tool(
     const content = await browserApi.getTabContent(tabId, offset);
     let links: { type: "text"; text: string }[] = [];
     if (offset === 0) {
-      // Only include the links if offset is 0 (default value). Otherwise, we can
-      // assume this is not the first call. Adding the links again would be redundant.
       links = content.links.map((link: { text: string; url: string }) => {
         return {
           type: "text",
-
           text: `Link text: ${link.text}, Link URL: ${link.url}`,
         };
       });
@@ -143,9 +284,6 @@ mcpServer.tool(
     let text = content.fullText;
     let hint: { type: "text"; text: string }[] = [];
     if (content.isTruncated || offset > 0) {
-      // If the content is truncated, add a "tip" suggesting
-      // that another tool, search in page, can be used to
-      // discover additional data.
       const rangeString = `${offset}-${offset + text.length}`;
       hint = [
         {
@@ -233,7 +371,6 @@ mcpServer.tool(
   }
 );
 
-const browserApi = new BrowserAPI();
 browserApi.init().catch((err) => {
   console.error("Browser API init error", err);
   process.exit(1);


### PR DESCRIPTION
## Summary

Adds container-aware Firefox tab management while preserving existing MCP tool names and text responses.

## Changes

- Adds structured tab/container metadata to tab listing and open-tab responses.
- Adds `activate-browser-tab` and `list-browser-containers`.
- Allows `open-browser-tab` to target a Firefox container by exact name or `cookieStoreId`.
- Filters tab listings by container, window ID, and active tab state.

## Notes

- Container resolution is exact-match only; ambiguous names require `cookieStoreId`.
- This PR is independent from the WebSocket readiness fix so either change can be reviewed or merged first.

## Validation

- `npm test` in `firefox-extension`
- `npm run build`
