### PR TITLE
Bind WebSocket server to 127.0.0.1 and ::1 so Firefox connects regardless of IPv4/IPv6 resolve order

### DIFF
--- a/mcp-server/browser-api.ts
+++ b/mcp-server/browser-api.ts
@@ -22,7 +22,7 @@ interface ExtensionRequestResolver<T extends ExtensionMessage["resource"]> {
 
 export class BrowserAPI {
   private ws: WebSocket | null = null;
-  private wsServer: WebSocket.Server | null = null;
+  private wsServers: WebSocket.Server[] = [];
   private sharedSecret: string | null = null;
 
   // Map to persist the request to the extension. It maps the request correlationId
@@ -47,45 +47,54 @@ export class BrowserAPI {
       );
     }
 
-    // Unless running in a container, bind to localhost only
-    const host = process.env.CONTAINERIZED ? "0.0.0.0" : "localhost";
+    // Bind explicitly to both loopback addresses so Firefox connects regardless of how
+    // it resolves "localhost". On Linux, getaddrinfo("localhost") often returns ::1
+    // before 127.0.0.1; binding only to "localhost" then yields an IPv6-only listener
+    // and IPv4 connect attempts get refused. Listening on 127.0.0.1 *and* ::1 keeps
+    // the server loopback-only (unlike "::"/"0.0.0.0", which would expose external
+    // interfaces), while accepting both IPv4 and IPv6 clients.
+    const hosts = process.env.CONTAINERIZED ? ["0.0.0.0"] : ["127.0.0.1", "::1"];
 
-    this.wsServer = new WebSocket.Server({
-      host,
-      port,
-    });
+    for (const host of hosts) {
+      const wsServer = new WebSocket.Server({ host, port });
 
-    console.error(`Starting WebSocket server on ${host}:${port}`);
-    this.wsServer.on("connection", async (connection) => {
-      this.ws = connection;
+      console.error(`Starting WebSocket server on ${host}:${port}`);
+      wsServer.on("connection", async (connection) => {
+        this.ws = connection;
 
-      console.error("WebSocket connection established on port", port);
+        console.error("WebSocket connection established on port", port);
 
-      this.ws.on("message", (message) => {
-        const decoded = JSON.parse(message.toString());
-        if (isErrorMessage(decoded)) {
-          this.handleExtensionError(decoded);
-          return;
-        }
-        const signature = this.createSignature(JSON.stringify(decoded.payload));
-        if (signature !== decoded.signature) {
-          console.error("Invalid message signature");
-          return;
-        }
-        this.handleDecodedExtensionMessage(decoded.payload);
+        this.ws.on("message", (message) => {
+          const decoded = JSON.parse(message.toString());
+          if (isErrorMessage(decoded)) {
+            this.handleExtensionError(decoded);
+            return;
+          }
+          const signature = this.createSignature(JSON.stringify(decoded.payload));
+          if (signature !== decoded.signature) {
+            console.error("Invalid message signature");
+            return;
+          }
+          this.handleDecodedExtensionMessage(decoded.payload);
+        });
       });
-    });
-    this.wsServer.on("error", (error) => {
-      console.error("WebSocket server error:", error);
-    });
+      wsServer.on("error", (error) => {
+        console.error(`WebSocket server error on ${host}:${port}:`, error);
+      });
+
+      this.wsServers.push(wsServer);
+    }
   }
 
   close() {
-    this.wsServer?.close();
+    for (const wsServer of this.wsServers) {
+      wsServer.close();
+    }
+    this.wsServers = [];
   }
 
   getSelectedPort() {
-    return this.wsServer?.options.port;
+    return this.wsServers[0]?.options.port;
   }
 
   async openTab(url: string): Promise<number | undefined> {


### PR DESCRIPTION
## Summary

- On Linux, `getaddrinfo("localhost")` often returns `::1` first, so the listener ends up IPv6-only on `[::1]:8089`. The Firefox extension occasionally resolves `localhost` to `127.0.0.1` and gets connection refused, producing intermittent `WebSocket is not open` errors.
- Listen explicitly on **both** loopback addresses (`127.0.0.1` and `::1`) so IPv4 and IPv6 clients both work, while keeping the server loopback-only (per maintainer's preference in [#52 (comment)](https://github.com/eyalzh/browser-control-mcp/pull/52#issuecomment-4394462593)). This avoids exposing the server on external interfaces, which `"::"`/`"0.0.0.0"` would do.
- Container path (`CONTAINERIZED=1` → `0.0.0.0`) is unchanged.

Fixes #51 (likely also resolves the symptom in #32).

## Implementation

`BrowserAPI` now holds an array of `WebSocket.Server` instances (one per host) instead of a single one. `init()` spins up a server per host and shares the same connection handler across them. `close()` closes all of them. `getSelectedPort()` returns the (single) port — both servers listen on the same port, just on different addresses.

## Before / after

```console
# before — IPv6 only, IPv4 connect refused
$ ss -tlnp | grep 8089
LISTEN [::1]:8089

# after — explicit dual-bind, loopback only
$ ss -tlnp | grep 8089
LISTEN 127.0.0.1:8089
LISTEN [::1]:8089

$ bash -c '</dev/tcp/127.0.0.1/8089'   # OK
$ bash -c '</dev/tcp/::1/8089'         # OK
```

End-to-end: `get-list-of-open-tabs` works reliably across Claude Code restarts on a box where it had been intermittent for days.

## Test plan

- [x] Smoke test: server starts, port listens on both `127.0.0.1` and `::1`, both IPv4 and IPv6 loopback accept TCP
- [x] End-to-end: Firefox extension reconnects after Claude Code restart and tools work
- [ ] (Reviewer) Confirm `CONTAINERIZED=1` path still binds `0.0.0.0` as before