### PR TITLE
Add optional Windows screenshot/control companion MCP server (contrib/)

### DIFF
--- a/contrib/windows-screenshot-mcp/README.md
+++ b/contrib/windows-screenshot-mcp/README.md
@@ -1,0 +1,67 @@
+# Windows Screenshot/Control MCP (optional companion)
+
+> **Heads-up — this is intentionally outside the Browser Control security model.**
+> Browser Control MCP is deliberately *read-mostly*: it cannot script pages, inject
+> input, or capture pixels, and every content read needs per-domain consent. This
+> companion does the opposite — it screenshots windows and synthesizes mouse/keyboard
+> input at the **OS level**. It is offered as a separate, opt-in helper for users who
+> specifically need screenshots and input automation on Windows (e.g. driving legacy
+> Flash/HTML5 content that only renders in Firefox). It is **not** wired into the
+> extension and does **not** use its consent mechanism. Use only on your own machine.
+
+A small, self-contained MCP server (Windows only) that automates a desktop window via
+PowerShell + .NET (`System.Windows.Forms` / `System.Drawing`). No browser extension and
+no network are involved.
+
+## Why this exists
+
+The extension-based design can't return screenshots (by design — capturing pixels and
+injecting input aren't part of the secure model). Some workflows still need to *see* a
+rendered tab and step through it (for example, content that renders only in Firefox).
+This companion fills that gap at the OS level, kept clearly separate so it never weakens
+the extension's guarantees.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `list_windows` | List visible top-level window titles. |
+| `focus_window` | Bring a window whose title contains a substring to the foreground. |
+| `screenshot` | Focus a window by title substring and capture it as a PNG (optional window-relative crop `x,y,w,h`). |
+| `press_keys` | Send keystrokes to the focused window (.NET `SendKeys` syntax, e.g. `{RIGHT}`, `{ENTER}`, `^{TAB}`). |
+| `click` | Left-click at window-relative coordinates (optional double-click). |
+
+## Requirements
+
+- Windows with PowerShell (built in).
+- Node.js 18+.
+
+## Install & run
+
+```bash
+cd contrib/windows-screenshot-mcp
+npm install
+node server.js
+```
+
+## MCP client configuration
+
+```json
+{
+  "mcpServers": {
+    "windows-screenshot": {
+      "command": "node",
+      "args": ["/absolute/path/to/contrib/windows-screenshot-mcp/server.js"]
+    }
+  }
+}
+```
+
+## Limitations & safety
+
+- **Windows only** (uses Win32 APIs via PowerShell).
+- Captures the **entire window** unless a crop region is given — be mindful of anything
+  else visible in that window.
+- Synthesizes real input to the foreground window; don't run it unattended on a machine
+  where stray clicks/keys could cause harm.
+- Coordinates for `click` are window-relative (top-left origin), matching what `screenshot` returns.

--- a/contrib/windows-screenshot-mcp/package.json
+++ b/contrib/windows-screenshot-mcp/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "windows-screenshot-mcp",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Optional, standalone Windows-only companion MCP server: window screenshot, keyboard, click, and focus via OS automation. NOT part of the Browser Control extension and does not use its consent model.",
+  "main": "server.js",
+  "bin": {
+    "windows-screenshot-mcp": "server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  }
+}

--- a/contrib/windows-screenshot-mcp/server.js
+++ b/contrib/windows-screenshot-mcp/server.js
@@ -1,0 +1,181 @@
+// Self-contained OS-automation MCP server (Windows) for driving a browser window
+// autonomously: window focus, screenshot, keypress, and click. Uses PowerShell +
+// .NET (System.Windows.Forms / System.Drawing) — no extension, no network.
+// Dependencies (@modelcontextprotocol/sdk, zod) are declared in this folder's package.json.
+"use strict";
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const { z } = require("zod");
+
+function ps(script) {
+  // Run a PowerShell script, return stdout (utf8). Throws on failure.
+  return execFileSync(
+    "powershell",
+    ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 }
+  );
+}
+
+// Shared C# helpers (window enum, focus, cursor, mouse, capture).
+const CS = `
+using System;
+using System.Text;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+public class Win {
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc cb, IntPtr l);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern int GetWindowText(IntPtr h, StringBuilder s, int n);
+  [DllImport("user32.dll")] public static extern int GetWindowTextLength(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int x, int y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint f, uint x, uint y, uint d, IntPtr e);
+  public delegate bool EnumWindowsProc(IntPtr h, IntPtr l);
+  public struct RECT { public int Left, Top, Right, Bottom; }
+  public static List<IntPtr> Found = new List<IntPtr>();
+  public static IntPtr FindByTitle(string sub) {
+    IntPtr res = IntPtr.Zero;
+    EnumWindows(delegate(IntPtr h, IntPtr l) {
+      if (!IsWindowVisible(h)) return true;
+      int len = GetWindowTextLength(h); if (len == 0) return true;
+      StringBuilder sb = new StringBuilder(len + 1); GetWindowText(h, sb, sb.Capacity);
+      string t = sb.ToString();
+      if (t.IndexOf(sub, StringComparison.OrdinalIgnoreCase) >= 0) { res = h; return false; }
+      return true;
+    }, IntPtr.Zero);
+    return res;
+  }
+  public static string ListTitles() {
+    StringBuilder outp = new StringBuilder();
+    EnumWindows(delegate(IntPtr h, IntPtr l) {
+      if (!IsWindowVisible(h)) return true;
+      int len = GetWindowTextLength(h); if (len == 0) return true;
+      StringBuilder sb = new StringBuilder(len + 1); GetWindowText(h, sb, sb.Capacity);
+      outp.Append(sb.ToString()).Append("\\n");
+      return true;
+    }, IntPtr.Zero);
+    return outp.ToString();
+  }
+  public const int SW_RESTORE = 9;
+  public const uint LEFTDOWN = 0x2, LEFTUP = 0x4;
+}
+`;
+
+function focusScript(title) {
+  return `Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
+${CS}
+"@
+$h=[Win]::FindByTitle(${JSON.stringify(title)})
+if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
+[Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
+[Win]::SetForegroundWindow($h) | Out-Null
+Start-Sleep -Milliseconds 400
+$r=New-Object Win+RECT; [Win]::GetWindowRect($h,[ref]$r) | Out-Null
+Write-Output ("RECT " + $r.Left + " " + $r.Top + " " + ($r.Right-$r.Left) + " " + ($r.Bottom-$r.Top))`;
+}
+
+const mcp = new McpServer({ name: "ff-auto", version: "1.0.0" });
+
+mcp.tool("list_windows", "List visible top-level window titles (to find the browser window)", {}, async () => {
+  const out = ps(`Add-Type @"
+${CS}
+"@
+[Win]::ListTitles()`);
+  return { content: [{ type: "text", text: out.trim() || "(none)" }] };
+});
+
+mcp.tool("focus_window",
+  "Bring the window whose title contains the given substring to the foreground. Returns its rect.",
+  { title: z.string() },
+  async ({ title }) => {
+    const out = ps(focusScript(title)).trim();
+    return { content: [{ type: "text", text: out }] };
+  });
+
+mcp.tool("screenshot",
+  "Focus the window matching `title` (substring) and capture it as a PNG. Optional crop x,y,w,h are window-relative. Returns the image.",
+  { title: z.string().default("Mozilla Firefox"),
+    x: z.number().optional(), y: z.number().optional(), w: z.number().optional(), h: z.number().optional() },
+  async ({ title, x, y, w, h }) => {
+    const tmp = path.join(os.tmpdir(), "ff-shot-" + Date.now() + ".png");
+    const crop = (x != null && y != null && w != null && h != null)
+      ? `$cx=${x};$cy=${y};$cw=${w};$ch=${h}` : `$cx=0;$cy=0;$cw=$ww;$ch=$wh`;
+    const out = ps(`Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
+${CS}
+"@
+$h=[Win]::FindByTitle(${JSON.stringify(title)})
+if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
+[Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
+[Win]::SetForegroundWindow($h) | Out-Null
+Start-Sleep -Milliseconds 450
+$r=New-Object Win+RECT; [Win]::GetWindowRect($h,[ref]$r) | Out-Null
+$ww=$r.Right-$r.Left; $wh=$r.Bottom-$r.Top
+${crop}
+$bmp=New-Object System.Drawing.Bitmap $cw,$ch
+$g=[System.Drawing.Graphics]::FromImage($bmp)
+$g.CopyFromScreen($r.Left+$cx,$r.Top+$cy,0,0,(New-Object System.Drawing.Size($cw,$ch)))
+$bmp.Save(${JSON.stringify(tmp)},[System.Drawing.Imaging.ImageFormat]::Png)
+$g.Dispose(); $bmp.Dispose()
+Write-Output ("OK " + $r.Left + " " + $r.Top + " " + $ww + " " + $wh)`).trim();
+    if (out.startsWith("NOTFOUND")) {
+      return { content: [{ type: "text", text: `Window matching "${title}" not found. Use list_windows.` }] };
+    }
+    const data = fs.readFileSync(tmp).toString("base64");
+    try { fs.unlinkSync(tmp); } catch (e) {}
+    return { content: [
+      { type: "text", text: out },
+      { type: "image", data, mimeType: "image/png" },
+    ] };
+  });
+
+mcp.tool("press_keys",
+  "Focus the window matching `title` and send keystrokes via SendKeys (e.g. '{RIGHT}', '{ENTER}', '{TAB}', 'a'). See .NET SendKeys syntax.",
+  { title: z.string().default("Mozilla Firefox"), keys: z.string() },
+  async ({ title, keys }) => {
+    const out = ps(`Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
+${CS}
+"@
+$h=[Win]::FindByTitle(${JSON.stringify(title)})
+if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
+[Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
+[Win]::SetForegroundWindow($h) | Out-Null
+Start-Sleep -Milliseconds 400
+[System.Windows.Forms.SendKeys]::SendWait(${JSON.stringify(keys)})
+Write-Output "SENT"`).trim();
+    return { content: [{ type: "text", text: out }] };
+  });
+
+mcp.tool("click",
+  "Focus the window matching `title`, then left-click at window-relative coordinates (x,y). Set double=true for double-click.",
+  { title: z.string().default("Mozilla Firefox"), x: z.number(), y: z.number(), double: z.boolean().default(false) },
+  async ({ title, x, y, double }) => {
+    const dbl = double ? `Start-Sleep -Milliseconds 60; [Win]::mouse_event([Win]::LEFTDOWN,0,0,0,[IntPtr]::Zero); [Win]::mouse_event([Win]::LEFTUP,0,0,0,[IntPtr]::Zero)` : "";
+    const out = ps(`Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
+${CS}
+"@
+$h=[Win]::FindByTitle(${JSON.stringify(title)})
+if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
+[Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
+[Win]::SetForegroundWindow($h) | Out-Null
+Start-Sleep -Milliseconds 350
+$r=New-Object Win+RECT; [Win]::GetWindowRect($h,[ref]$r) | Out-Null
+[Win]::SetCursorPos($r.Left+${x}, $r.Top+${y}) | Out-Null
+Start-Sleep -Milliseconds 120
+[Win]::mouse_event([Win]::LEFTDOWN,0,0,0,[IntPtr]::Zero)
+[Win]::mouse_event([Win]::LEFTUP,0,0,0,[IntPtr]::Zero)
+${dbl}
+Write-Output ("CLICK " + ($r.Left+${x}) + " " + ($r.Top+${y}))`).trim();
+    return { content: [{ type: "text", text: out }] };
+  });
+
+const transport = new StdioServerTransport();
+mcp.connect(transport).catch((e) => { console.error("ff-auto connect error", e); process.exit(1); });
+process.stdin.on("close", () => { mcp.close(); process.exit(0); });

--- a/contrib/windows-screenshot-mcp/server.js
+++ b/contrib/windows-screenshot-mcp/server.js
@@ -20,12 +20,12 @@ function ps(script) {
   );
 }
 
+function psq(s){ return "'" + String(s).replace(/'/g, "''") + "'"; }
+
 // Shared C# helpers (window enum, focus, cursor, mouse, capture).
 const CS = `
 using System;
 using System.Text;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 public class Win {
@@ -73,7 +73,7 @@ function focusScript(title) {
   return `Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
 ${CS}
 "@
-$h=[Win]::FindByTitle(${JSON.stringify(title)})
+$h=[Win]::FindByTitle(${psq(title)})
 if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
 [Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
 [Win]::SetForegroundWindow($h) | Out-Null
@@ -111,7 +111,7 @@ mcp.tool("screenshot",
     const out = ps(`Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
 ${CS}
 "@
-$h=[Win]::FindByTitle(${JSON.stringify(title)})
+$h=[Win]::FindByTitle(${psq(title)})
 if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
 [Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
 [Win]::SetForegroundWindow($h) | Out-Null
@@ -122,7 +122,7 @@ ${crop}
 $bmp=New-Object System.Drawing.Bitmap $cw,$ch
 $g=[System.Drawing.Graphics]::FromImage($bmp)
 $g.CopyFromScreen($r.Left+$cx,$r.Top+$cy,0,0,(New-Object System.Drawing.Size($cw,$ch)))
-$bmp.Save(${JSON.stringify(tmp)},[System.Drawing.Imaging.ImageFormat]::Png)
+$bmp.Save(${psq(tmp)},[System.Drawing.Imaging.ImageFormat]::Png)
 $g.Dispose(); $bmp.Dispose()
 Write-Output ("OK " + $r.Left + " " + $r.Top + " " + $ww + " " + $wh)`).trim();
     if (out.startsWith("NOTFOUND")) {
@@ -143,12 +143,12 @@ mcp.tool("press_keys",
     const out = ps(`Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
 ${CS}
 "@
-$h=[Win]::FindByTitle(${JSON.stringify(title)})
+$h=[Win]::FindByTitle(${psq(title)})
 if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
 [Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
 [Win]::SetForegroundWindow($h) | Out-Null
 Start-Sleep -Milliseconds 400
-[System.Windows.Forms.SendKeys]::SendWait(${JSON.stringify(keys)})
+[System.Windows.Forms.SendKeys]::SendWait(${psq(keys)})
 Write-Output "SENT"`).trim();
     return { content: [{ type: "text", text: out }] };
   });
@@ -161,7 +161,7 @@ mcp.tool("click",
     const out = ps(`Add-Type -AssemblyName System.Windows.Forms,System.Drawing; Add-Type @"
 ${CS}
 "@
-$h=[Win]::FindByTitle(${JSON.stringify(title)})
+$h=[Win]::FindByTitle(${psq(title)})
 if($h -eq [IntPtr]::Zero){ Write-Output "NOTFOUND"; exit }
 [Win]::ShowWindow($h,[Win]::SW_RESTORE) | Out-Null
 [Win]::SetForegroundWindow($h) | Out-Null


### PR DESCRIPTION
## Summary

Adds an **optional, standalone, Windows-only companion** MCP server under `contrib/windows-screenshot-mcp/` that provides window **screenshot**, **keyboard**, **click**, and **window-focus** tools via PowerShell + .NET (`System.Windows.Forms` / `System.Drawing`). No browser extension and no network are involved.

It lives entirely under `contrib/` and does not touch the extension, the existing MCP server, the build, or the message protocol.

## Why

The extension-based design intentionally can't return screenshots or inject input. Some workflows still need to *see* a rendered tab and step through it — for example, legacy Flash/HTML5 content that only renders in Firefox. This fills that gap at the OS level for users who specifically want it.

## Honest caveat (please read before considering)

This is **deliberately outside this project's security model**. Browser Control MCP is read-mostly by design — no page scripting, no input injection, per-domain consent for content reads. This companion does the opposite (captures pixels, synthesizes mouse/keyboard at the OS level) and does **not** use the consent mechanism.

I've kept it fully separate and labeled it as such (prominent warning in its README, isolated `contrib/` folder, its own `package.json`) precisely so it can't weaken the extension's guarantees. **Completely understand if this doesn't fit the project's philosophy and you'd rather not take it** — posting it as an opt-in helper in case it's useful to others, and happy to adjust or close.

## Contents
- `contrib/windows-screenshot-mcp/server.js` — the MCP server (5 tools)
- `contrib/windows-screenshot-mcp/package.json` — standalone deps
- `contrib/windows-screenshot-mcp/README.md` — usage + security caveat

## Notes
- Windows only.
- Does not modify any existing project, build target, or test.
