### PR TITLE
Cap oversized tab content responses

### DIFF
--- a/firefox-extension/__tests__/message-handler.test.ts
+++ b/firefox-extension/__tests__/message-handler.test.ts
@@ -1,6 +1,9 @@
 import { MessageHandler } from "../message-handler";
 import { WebsocketClient } from "../client";
-import type { ServerMessageRequest } from "@browser-control-mcp/common";
+import type {
+  ServerMessageRequest,
+  TabContentExtensionMessage,
+} from "@browser-control-mcp/common";
 import { ExtensionConfig } from "../extension-config";
 import { grantCaptureConsent, revokeCaptureConsent } from "../capture-consent";
 
@@ -382,6 +385,41 @@ describe("MessageHandler", () => {
           links: [{ url: "https://example.com/page", text: "Page" }],
           totalLength: 12,
         });
+      });
+
+      it("should cap oversized tab content before sending it", async () => {
+        const request: ServerMessageRequest = {
+          cmd: "get-tab-content",
+          tabId: 123,
+          correlationId: "test-correlation-id",
+        };
+
+        (browser.tabs.get as jest.Mock).mockResolvedValue({
+          id: 123,
+          url: "https://example.com",
+        });
+        (browser.permissions.contains as jest.Mock).mockResolvedValue(true);
+        (browser.tabs.executeScript as jest.Mock).mockResolvedValue([
+          {
+            links: [
+              {
+                url: "https://example.com/page",
+                text: "😀".repeat(500_000),
+              },
+            ],
+            fullText: "Page content",
+            isTruncated: false,
+            totalLength: 12,
+          },
+        ]);
+
+        await messageHandler.handleDecodedMessage(request);
+
+        const sentMessage = mockClient.sendResourceToServer.mock
+          .calls[0][0] as TabContentExtensionMessage;
+        const responseBytes = Buffer.byteLength(JSON.stringify(sentMessage));
+        expect(responseBytes).toBeLessThanOrEqual(2_000_000);
+        expect(sentMessage.isTruncated).toBe(true);
       });
 
       it("should throw an error if tab URL domain is in deny list", async () => {

--- a/firefox-extension/message-handler.ts
+++ b/firefox-extension/message-handler.ts
@@ -1,10 +1,14 @@
-import type { ServerMessageRequest } from "@browser-control-mcp/common";
+import type {
+  ServerMessageRequest,
+  TabContentExtensionMessage,
+} from "@browser-control-mcp/common";
 import { WebsocketClient } from "./client";
 import { isCommandAllowed, isDomainInDenyList, COMMAND_TO_TOOL_ID, addAuditLogEntry } from "./extension-config";
 import { hasCaptureConsent, markTabAsAwaitingConsent } from "./capture-consent";
 
 // Time to let a newly foregrounded tab paint before capturing it
 const TAB_PAINT_DELAY_MS = 250;
+const MAX_TAB_CONTENT_RESPONSE_BYTES = 2_000_000;
 
 export class MessageHandler {
   private client: WebsocketClient;
@@ -253,7 +257,7 @@ export class MessageHandler {
     `,
     });
     const { isTruncated, fullText, links, totalLength } = results[0];
-    await this.client.sendResourceToServer({
+    const message: TabContentExtensionMessage = {
       resource: "tab-content",
       tabId,
       correlationId,
@@ -261,7 +265,14 @@ export class MessageHandler {
       fullText,
       links,
       totalLength,
-    });
+    };
+    const responseSize = new Blob([JSON.stringify(message)]).size;
+    if (responseSize > MAX_TAB_CONTENT_RESPONSE_BYTES) {
+      message.fullText = fullText.substring(0, MAX_CONTENT_LENGTH);
+      message.links = [];
+      message.isTruncated = true;
+    }
+    await this.client.sendResourceToServer(message);
   }
 
   private async reorderTabs(


### PR DESCRIPTION
## Summary

- Measure serialized tab-content responses in encoded bytes before WebSocket delivery.
- Drop the link list and mark the response truncated when it exceeds 2 MB.
- Preserve the existing 50,000-character text cap.

Addresses the server-side mitigation requested in #54.
Supersedes the response-cap portion of #55.

## Verification

- `npm run build`
- `cd firefox-extension && npm test -- --runInBand` (24 tests)
