### PR TITLE
Fix reproducible Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.nx
+.worktrees
+node_modules
+*/node_modules
+dist
+*/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY common/ ./common/
 # Set working directory to mcp-server for installation
 WORKDIR /app/mcp-server
 
-# Install dependencies
-RUN npm install
+# Install dependencies from the committed lockfile
+RUN npm ci --no-audit --no-fund
 
 # Copy mcp-server source code
 COPY mcp-server/ ./

--- a/common/package.json
+++ b/common/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@browser-control-mcp/common",
+  "version": "1.5.2",
+  "private": true,
+  "types": "index.ts"
+}


### PR DESCRIPTION
## Summary

- Exclude host dependencies and build output from the Docker context.
- Install MCP server dependencies with the committed lockfile.
- Define the shared local dependency as an npm package.

Fixes #39.
Supersedes the Docker portion of #55.

## Verification

- `npm ci --package-lock-only --ignore-scripts --offline --no-audit --no-fund` against the Docker dependency layout
- `npm run build`
- `cd firefox-extension && npm test -- --runInBand` (23 tests)
- `cd common && npm pack --dry-run --json`

A container build could not run in this environment because Docker is unavailable and the installed Podman VM cannot start without `krunkit`.
